### PR TITLE
Update v0.7.0 to v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Fixed
 
+### Changed
+
+## [0.7.1]
+
+### Added
+
+### Fixed
+
  - Fixed `ins_size`, `ins_size_dev` & `coverage_uniformity` parsing and models
  - Check first 1000 reads if paired instead of just first read
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN /bin/bash -c "source ~/.bashrc"
 LABEL authors="Markus Johansson <markus.h.johansson@skane.se>, Ryan Kennedy <ryan.kennedy@skane.se>" \
       maintainers="Markus Johansson <markus.h.johansson@skane.se>, Ryan Kennedy <ryan.kennedy@skane.se>" \
       description="Docker image for bonsai-prp" \
-      version="0.7.0"
+      version="0.7.1"
 
 # Default command to run when the container starts
 CMD ["python"]

--- a/prp/__version__.py
+++ b/prp/__version__.py
@@ -1,2 +1,2 @@
 """PRP version"""
-VERSION = "0.7.0"
+VERSION = "0.7.1"


### PR DESCRIPTION
Update to v0.7.1 as there are only minor changes. v0.7.0 works for most use cases but not for sequencing technology that don't produce insert size metrics.