### PR TITLE
Updated PRP to version 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## [0.8.0]
+
+### Added
+
  - Added `rerun_bonsai_input` to rerun bonsai-prp outputs when output format changes
  - Added `symlink_dir` as possible filepaths prefix for IGV inputs
  - Added kraken cutoff whereby species prediction needs to have >= 0.01% of read hits

--- a/prp/__version__.py
+++ b/prp/__version__.py
@@ -1,2 +1,2 @@
 """PRP version"""
-VERSION = "0.7.1"
+VERSION = "0.8.0"

--- a/prp/cli.py
+++ b/prp/cli.py
@@ -1,18 +1,17 @@
 """Definition of the PRP command-line interface."""
-from prp import VERSION as __version__
-
-import os
 import json
 import logging
 from pathlib import Path
 from typing import List
 
 import click
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pysam
 from cyvcf2 import VCF, Writer
 from pydantic import TypeAdapter, ValidationError
+
+from prp import VERSION as __version__
 
 from .models.metadata import SoupType, SoupVersion
 from .models.phenotype import ElementType
@@ -38,11 +37,9 @@ from .parse import (
     parse_virulencefinder_stx_typing,
     parse_virulencefinder_vir_pred,
 )
-from .parse.mapping import get_reference_seq_accnr
 from .parse.metadata import get_database_info, get_gb_genome_version, parse_run_info
-from .parse.utils import get_db_version, parse_input_dir
+from .parse.utils import _get_path, get_db_version, parse_input_dir
 from .parse.variant import annotate_delly_variants
-from .parse.utils import _get_path
 
 logging.basicConfig(
     level=logging.INFO, format="[%(asctime)s] %(levelname)s in %(module)s: %(message)s"
@@ -245,7 +242,7 @@ def create_bonsai_input(
         pred_res = pd.read_csv(mykrobe, quotechar='"')
         pred_res.columns.values[3] = "variants"
         pred_res.columns.values[4] = "genes"
-        pred_res.replace(['NA', np.nan], None, inplace=True)
+        pred_res.replace(["NA", np.nan], None, inplace=True)
         pred_res = pred_res.to_dict(orient="records")
 
         # verify that sample id is in prediction result
@@ -345,10 +342,33 @@ def create_bonsai_input(
 
 
 @cli.command()
-@click.option("-i", "--input-dir",  required=True, type=click.Path(exists=True, file_okay=False, dir_okay=True), help="Input directory to JASEN's outdir incl. speciesDir")
-@click.option("-j", "--jasen-dir",  required=True, type=click.Path(exists=True, file_okay=False, dir_okay=True), help="Path to JASEN directory")
-@click.option("-s", "--symlink_dir",  required=False, type=click.Path(exists=True, file_okay=False, dir_okay=True), help="Path to symlink directory")
-@click.option("-o", "--output-dir", type=click.Path(file_okay=False, dir_okay=True), help="Output directory to incl. speciesDir [default: input_dir]")
+@click.option(
+    "-i",
+    "--input-dir",
+    required=True,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+    help="Input directory to JASEN's outdir incl. speciesDir",
+)
+@click.option(
+    "-j",
+    "--jasen-dir",
+    required=True,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+    help="Path to JASEN directory",
+)
+@click.option(
+    "-s",
+    "--symlink_dir",
+    required=False,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+    help="Path to symlink directory",
+)
+@click.option(
+    "-o",
+    "--output-dir",
+    type=click.Path(file_okay=False, dir_okay=True),
+    help="Output directory to incl. speciesDir [default: input_dir]",
+)
 @click.pass_context
 def rerun_bonsai_input(ctx, input_dir, jasen_dir, symlink_dir, output_dir) -> None:
     """Rerun bonsai input creation for all samples in input directory."""
@@ -439,7 +459,11 @@ def create_qc_result(sample_id, bam, bed, baits, reference, cpus, output) -> Non
 @click.option("-v", "--vcf", type=click.Path(exists=True), help="VCF file")
 @click.option("-b", "--bed", type=click.Path(exists=True), help="BED file")
 @click.option(
-    "-o", "--output", required=True, type=click.Path(writable=True), help="output filepath"
+    "-o",
+    "--output",
+    required=True,
+    type=click.Path(writable=True),
+    help="output filepath",
 )
 def annotate_delly(vcf, bed, output):
     """Annotate Delly SV varinats with genes in BED file."""
@@ -456,7 +480,11 @@ def annotate_delly(vcf, bed, output):
     if not variant.CHROM in annotation.contigs:
         if len(annotation.contigs) > 1:
             raise click.UsageError(
-                f'"{variant.CHROM}" not in BED file and the file contains {len(annotation.contigs)} chromosomes'
+                (
+                    f'"{variant.CHROM}" not in BED file'
+                    " and the file contains "
+                    f"{len(annotation.contigs)} chromosomes"
+                )
             )
         # if there is only one "chromosome" in the bed file
         annot_chrom = True

--- a/prp/parse/mapping.py
+++ b/prp/parse/mapping.py
@@ -1,7 +1,6 @@
 """Parse mapping and alignment files."""
 
 import pysam
-from Bio import SeqIO
 
 
 def get_reference_seq_accnr(bam_path: str) -> str:

--- a/prp/parse/metadata.py
+++ b/prp/parse/metadata.py
@@ -39,7 +39,7 @@ def parse_run_info(run_metadata: str) -> RunInformation:
     :rtype: RunMetadata
     """
     LOG.info("Parse run metadata.")
-    with open(run_metadata, "r") as jsonfile:
+    with open(run_metadata, encoding="utf-8") as jsonfile:
         run_info = RunInformation(**json.load(jsonfile))
     return run_info
 

--- a/prp/parse/phenotype/mykrobe.py
+++ b/prp/parse/phenotype/mykrobe.py
@@ -96,7 +96,7 @@ def _parse_mykrobe_amr_variants(mykrobe_result) -> Tuple[MykrobeVariant, ...]:
 
         variants = element_type["variants"].split(";")
         # Mykrobe CSV variant format
-        # <gene>_<amino acid change>-<dna change>:<ref depth>:<alt depth>:<genotype confidence>
+        # <gene>_<aa change>-<nt change>:<ref depth>:<alt depth>:<gt confidence>
         # ref: https://github.com/Mykrobe-tools/mykrobe/wiki/AMR-prediction-output
         pattern = re.compile(r"(.+)_(.+)-(.+):(\d+):(\d+):(\d+)", re.I)
         for var_id, variant in enumerate(variants, start=1):

--- a/prp/parse/phenotype/resfinder.py
+++ b/prp/parse/phenotype/resfinder.py
@@ -295,8 +295,7 @@ def _parse_resfinder_amr_variants(
     for var_id, info in enumerate(resfinder_result["seq_variations"].values(), start=1):
         # Get only variants from desired phenotypes
         if limit_to_phenotypes is not None:
-            intersect = set(info["phenotypes"]) & set(limit_to_phenotypes)
-            if len(intersect) == 0:
+            if len(set(info["phenotypes"]) & set(limit_to_phenotypes)) == 0:
                 continue
         # get gene depth
         if "seq_regions" in resfinder_result:
@@ -306,7 +305,6 @@ def _parse_resfinder_amr_variants(
         else:
             info["depth"] = 0
         # translate variation type bools into classifier
-        var_type = VariantType.SNV
         if info["substitution"]:
             var_sub_type = VariantSubType.SUBSTITUTION
         elif info["insertion"]:
@@ -331,7 +329,7 @@ def _parse_resfinder_amr_variants(
         ]
         variant = ResfinderVariant(
             id=var_id,
-            variant_type=var_type,
+            variant_type=VariantType.SNV,
             variant_subtype=var_sub_type,
             phenotypes=phenotype,
             # position

--- a/prp/parse/phenotype/tbprofiler.py
+++ b/prp/parse/phenotype/tbprofiler.py
@@ -59,7 +59,7 @@ def _parse_tbprofiler_amr_variants(predictions) -> Tuple[TbProfilerVariant, ...]
     # tbprofiler report three categories of variants
     # - dr_variants: known resistance variants
     # - qc_fail_variants: known resistance variants failing qc
-    # - other_variants: variants not in the database but in genes 
+    # - other_variants: variants not in the database but in genes
     #                   associated with resistance
     var_id = 1
     for result_type in ["dr_variants", "other_variants", "qc_fail_variants"]:
@@ -129,8 +129,11 @@ def parse_drug_resistance_info(drugs: List[Dict[str, str]]) -> List[PhenotypeInf
             drug_type = ElementType.AMR
         else:
             drug_type = ElementType.AMR
-            LOG.warning(
-                "Unknown TbProfiler drug; drug: %s, confers resistance with confidence: %s; default to %s",
+            LOG.warning((
+                "Unknown TbProfiler drug; drug: %s"
+                ", confers resistance with confidence"
+                ": %s; default to %s"
+            ),
                 drug["type"],
                 drug["confidence"],
                 drug_type,

--- a/prp/parse/phenotype/virulencefinder.py
+++ b/prp/parse/phenotype/virulencefinder.py
@@ -51,7 +51,7 @@ def _parse_virulencefinder_vir_results(pred: str) -> ElementTypeResult:
         match virulence_group:
             case "toxin":
                 subtype = ElementVirulenceSubtype.TOXIN
-            case other:
+            case _:
                 subtype = ElementVirulenceSubtype.VIR
         # parse genes
         if not genes == "No hit found":

--- a/prp/parse/qc.py
+++ b/prp/parse/qc.py
@@ -114,7 +114,9 @@ class QC:
                 return True
             if i >= 1000:
                 break
-        # If no paired reads are found in the first 1000 reads or read is None, return False
+        # If no paired reads are found in the
+        # first 1000 reads or read is None
+        # return False
         return False
 
     def system_p(self, cmd: list) -> None:
@@ -277,14 +279,20 @@ def parse_postalignqc_results(postalignqc_fpath: str) -> QcMethodIndex:
     with open(postalignqc_fpath, "r", encoding="utf-8") as jsonfile:
         qc_dict = json.load(jsonfile)
         qc_res = PostAlignQcResult(
-            ins_size=None if "ins_size" not in qc_dict else int(float(qc_dict["ins_size"])),
-            ins_size_dev=None if "ins_size_dev" not in qc_dict else int(float(qc_dict["ins_size_dev"])),
+            ins_size=None
+            if "ins_size" not in qc_dict
+            else int(float(qc_dict["ins_size"])),
+            ins_size_dev=None
+            if "ins_size_dev" not in qc_dict
+            else int(float(qc_dict["ins_size_dev"])),
             mean_cov=int(qc_dict["mean_cov"]),
             pct_above_x=qc_dict["pct_above_x"],
             n_reads=int(qc_dict["n_reads"]),
             n_mapped_reads=int(qc_dict["n_mapped_reads"]),
             n_read_pairs=int(qc_dict["n_read_pairs"]),
-            coverage_uniformity=float(qc_dict["coverage_uniformity"]) if qc_dict.get("coverage_uniformity") is not None else None,
+            coverage_uniformity=float(qc_dict["coverage_uniformity"])
+            if qc_dict.get("coverage_uniformity") is not None
+            else None,
             quartile1=float(qc_dict["quartile1"]),
             median_cov=float(qc_dict["median_cov"]),
             quartile3=float(qc_dict["quartile3"]),

--- a/prp/parse/species.py
+++ b/prp/parse/species.py
@@ -22,6 +22,6 @@ def parse_kraken_result(file: str, cutoff: float = 0.0001):
         .sort_values("fraction_total_reads", ascending=False)
         .rename(columns=columns)
         .replace({"taxonomy_lvl": tax_lvl_dict})
-        .loc[lambda df: df['fraction_total_reads'] >= cutoff]
+        .loc[lambda df: df["fraction_total_reads"] >= cutoff]
     )
     return species_pred.to_dict(orient="records")

--- a/prp/parse/typing.py
+++ b/prp/parse/typing.py
@@ -11,8 +11,8 @@ from ..models.typing import (
     TypingMethod,
     TypingResultCgMlst,
     TypingResultGeneAllele,
-    TypingResultPhylogenetics,
     TypingResultMlst,
+    TypingResultPhylogenetics,
 )
 from ..models.typing import TypingSoftware as Software
 from .phenotype.serotypefinder import parse_serotype_gene
@@ -119,7 +119,9 @@ def parse_cgmlst_results(
     )
 
 
-def parse_tbprofiler_lineage_results(pred_res: dict, method) -> TypingResultPhylogenetics:
+def parse_tbprofiler_lineage_results(
+    pred_res: dict, method
+) -> TypingResultPhylogenetics:
     """Parse tbprofiler results for lineage object."""
     LOG.info("Parsing lineage results")
     result_obj = TypingResultPhylogenetics(
@@ -135,14 +137,16 @@ def parse_tbprofiler_lineage_results(pred_res: dict, method) -> TypingResultPhyl
     return MethodIndex(type=method, software=Software.TBPROFILER, result=result_obj)
 
 
-def parse_mykrobe_lineage_results(pred_res: dict, method) -> TypingResultPhylogenetics | None:
+def parse_mykrobe_lineage_results(
+    pred_res: dict, method
+) -> TypingResultPhylogenetics | None:
     """Parse mykrobe results for lineage object."""
     LOG.info("Parsing lineage results")
     if pred_res:
         lineage = pred_res[0]
-        phylo_group_depth=lineage["phylo_group_depth"]
-        species_depth=lineage["species_depth"]
-        lineage_depth=lineage["lineage_depth"]
+        phylo_group_depth = lineage["phylo_group_depth"]
+        species_depth = lineage["species_depth"]
+        lineage_depth = lineage["lineage_depth"]
         split_lin = lineage["lineage"].split(".")
         main_lin = split_lin[0]
         sublin = lineage["lineage"]
@@ -153,7 +157,9 @@ def parse_mykrobe_lineage_results(pred_res: dict, method) -> TypingResultPhyloge
         ]
         # cast to lineage object
         result_obj = TypingResultPhylogenetics(
-            phylo_group_depth=float(phylo_group_depth) if phylo_group_depth else phylo_group_depth,
+            phylo_group_depth=float(phylo_group_depth)
+            if phylo_group_depth
+            else phylo_group_depth,
             species_depth=float(species_depth) if species_depth else species_depth,
             lineage_depth=float(lineage_depth) if lineage_depth else lineage_depth,
             phylo_group=lineage["phylo_group"],
@@ -163,6 +169,7 @@ def parse_mykrobe_lineage_results(pred_res: dict, method) -> TypingResultPhyloge
             lineages=lineages,
         )
         return MethodIndex(type=method, software=Software.MYKROBE, result=result_obj)
+    return None
 
 
 def parse_virulencefinder_stx_typing(path: str) -> MethodIndex | None:

--- a/prp/parse/typing.py
+++ b/prp/parse/typing.py
@@ -58,7 +58,7 @@ def parse_mlst_results(mlst_fpath: str) -> TypingResultMlst:
 
 
 def parse_cgmlst_results(
-    file: str, include_novel_alleles: bool = True, correct_alleles: bool = False
+    chewbacca_res_path: str, include_novel_alleles: bool = True, correct_alleles: bool = False
 ) -> TypingResultCgMlst:
     """Parse chewbbaca cgmlst prediction results to json results.
 
@@ -104,10 +104,11 @@ def parse_cgmlst_results(
         "not" if not include_novel_alleles else "",
     )
 
-    creader = csv.reader(file, delimiter="\t")
-    _, *allele_names = (colname.rstrip(".fasta") for colname in next(creader))
-    # parse alleles
-    _, *alleles = next(creader)
+    with open(chewbacca_res_path, encoding='utf-8') as fileh:
+        creader = csv.reader(fileh, delimiter="\t")
+        _, *allele_names = (colname.rstrip(".fasta") for colname in next(creader))
+        # parse alleles
+        _, *alleles = next(creader)
     corrected_alleles = (replace_errors(a) for a in alleles)
     results = TypingResultCgMlst(
         n_novel=sum(1 for a in alleles if a.startswith("INF")),

--- a/prp/parse/variant.py
+++ b/prp/parse/variant.py
@@ -19,7 +19,7 @@ def _get_variant_type(variant) -> VariantType:
             var_type = VariantType.SNV
         case "mnp":
             var_type = VariantType.MNV
-        case other:
+        case _:
             var_type = VariantType(variant.var_type.upper())
     return var_type
 
@@ -57,6 +57,7 @@ def _get_variant_caller(vcf_obj: VCF) -> str | None:
     match = re.search(SOURCE_PATTERN, vcf_obj.raw_header)
     if match:
         return match.group(1)
+    return None
 
 
 def load_variants(variant_file: str) -> List[VariantBase]:
@@ -81,6 +82,7 @@ def load_variants(variant_file: str) -> List[VariantBase]:
 
 
 def annotate_delly_variants(writer, vcf, annotation, annot_chrom=False):
+    """Annotate a variant called by Delly."""
     locus_tag = 3
     gene_symbol = 4
     # annotate variant

--- a/tests/fixtures/mtuberculosis/__init__.py
+++ b/tests/fixtures/mtuberculosis/__init__.py
@@ -2,8 +2,6 @@
 
 import pytest
 
-from ..fixtures import data_path
-
 
 @pytest.fixture()
 def mtuberculosis_analysis_meta_path(data_path):

--- a/tests/fixtures/mtuberculosis/tbprofiler.json
+++ b/tests/fixtures/mtuberculosis/tbprofiler.json
@@ -1,1335 +1,5979 @@
 {
-  "id": "test_mtuberculosis_1",
-  "tbprofiler_version": "4.4.2",
-  "qc": {
-    "pct_reads_mapped": 98.26,
-    "num_reads_mapped": 6004294,
-    "median_coverage": 194,
-    "gene_coverage": [
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv0005", "gene": "gyrB" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv0006", "gene": "gyrA" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv0407", "gene": "fgd1" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv0486", "gene": "mshA" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv0529", "gene": "ccsA" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv0667", "gene": "rpoB" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv0668", "gene": "rpoC" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv0676c", "gene": "mmpL5" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv0677c", "gene": "mmpS5" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv0678", "gene": "mmpR5" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv0682", "gene": "rpsL" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv0701", "gene": "rplC" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv1173", "gene": "fbiC" },
-      {
-        "fraction": 0.0,
-        "cutoff": 0,
-        "locus_tag": "Rv1258c",
-        "gene": "Rv1258c"
-      },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv1267c", "gene": "embR" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv1305", "gene": "atpE" },
-      {
-        "fraction": 0.0,
-        "cutoff": 0,
-        "locus_tag": "EBG00000313325",
-        "gene": "rrs"
-      },
-      {
-        "fraction": 0.0,
-        "cutoff": 0,
-        "locus_tag": "EBG00000313339",
-        "gene": "rrl"
-      },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv1483", "gene": "fabG1" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv1484", "gene": "inhA" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv1630", "gene": "rpsA" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv1694", "gene": "tlyA" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv1854c", "gene": "ndh" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv1908c", "gene": "katG" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv1918c", "gene": "PPE35" },
-      {
-        "fraction": 0.0,
-        "cutoff": 0,
-        "locus_tag": "Rv1979c",
-        "gene": "Rv1979c"
-      },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv2043c", "gene": "pncA" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv2245", "gene": "kasA" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv2416c", "gene": "eis" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv2428", "gene": "ahpC" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv2447c", "gene": "folC" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv2535c", "gene": "pepQ" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv2671", "gene": "ribD" },
-      {
-        "fraction": 0.0,
-        "cutoff": 0,
-        "locus_tag": "Rv2752c",
-        "gene": "Rv2752c"
-      },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv2754c", "gene": "thyX" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv2764c", "gene": "thyA" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv2780", "gene": "ald" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv2983", "gene": "fbiD" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3083", "gene": "Rv3083" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3106", "gene": "fprA" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3197A", "gene": "whiB7" },
-      {
-        "fraction": 0.0,
-        "cutoff": 0,
-        "locus_tag": "Rv3236c",
-        "gene": "Rv3236c"
-      },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3261", "gene": "fbiA" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3262", "gene": "fbiB" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3423c", "gene": "alr" },
-      {
-        "fraction": 0.016632016632016633,
-        "cutoff": 0,
-        "locus_tag": "Rv3457c",
-        "gene": "rpoA"
-      },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3547", "gene": "ddn" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3596c", "gene": "clpC1" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3601c", "gene": "panD" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3793", "gene": "embC" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3794", "gene": "embA" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3795", "gene": "embB" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3805c", "gene": "aftB" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3806c", "gene": "ubiA" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3854c", "gene": "ethA" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3855", "gene": "ethR" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3862c", "gene": "whiB6" },
-      { "fraction": 0.0, "cutoff": 0, "locus_tag": "Rv3919c", "gene": "gid" }
+    "id": "test_mtuberculosis_1",
+    "timestamp": "2024-05-15T15:21:24.742254",
+    "pipeline": {
+        "software_version": "6.2.0",
+        "db_version": {
+            "name": "converged_who_fohm_tbdb",
+            "Date": "2024-05-08 16:25:28.388882",
+            "Author": "NA"
+        },
+        "software": [
+            {
+                "process": "trimming",
+                "software": "trimmomatic"
+            },
+            {
+                "process": "mapping",
+                "software": "bwa"
+            },
+            {
+                "process": "variant_calling",
+                "software": "freebayes"
+            },
+            {
+                "process": "depth_calculation",
+                "software": "samtools"
+            }
+        ]
+    },
+    "notes": [
+        "Rule applied: Variant(gene_name=eis,type=lof) inactivates_resistance Variant(gene_name=eis)"
     ],
-    "missing_positions": []
-  },
-  "delly": "success",
-  "input_data_source": "fastq",
-  "lineage": [
-    {
-      "lin": "lineage2",
-      "family": "East-Asian",
-      "spoligotype": "Beijing",
-      "rd": "RD105",
-      "frac": 0.9989017023613399
-    },
-    {
-      "lin": "lineage2.2",
-      "family": "East-Asian (Beijing)",
-      "spoligotype": "Beijing-RD207",
-      "rd": "RD105;RD207",
-      "frac": 0.9980324643384161
-    },
-    {
-      "lin": "lineage2.2.1",
-      "family": "East-Asian (Beijing)",
-      "spoligotype": "Beijing-RD181",
-      "rd": "RD105;RD207;RD181",
-      "frac": 0.998792270531401
-    }
-  ],
-  "main_lin": "lineage2",
-  "sublin": "lineage2.2.1",
-  "dr_variants": [
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 761104,
-      "ref": "TCATGGA",
-      "alt": "T",
-      "depth": 151,
-      "freq": 1.0,
-      "feature_id": "CCP43410",
-      "type": "conservative_inframe_deletion",
-      "nucleotide_change": "c.1300_1305delATGGAC",
-      "protein_change": "p.Met434_Asp435del",
-      "annotation": [
+    "lineage": [
         {
-          "type": "who_confidence",
-          "drug": "rifampicin",
-          "who_confidence": "Assoc w R - interim"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "c.1300_1305delATGGAC",
-      "locus_tag": "Rv0667",
-      "gene": "rpoB",
-      "drugs": [
-        {
-          "type": "drug",
-          "drug": "rifampicin",
-          "literature": "https://www.who.int/publications/i/item/9789240028173",
-          "confers": "resistance",
-          "who confidence": "Assoc w R - interim"
-        }
-      ],
-      "gene_associated_drugs": ["rifampicin"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 781822,
-      "ref": "A",
-      "alt": "G",
-      "depth": 236,
-      "freq": 0.9957627118644068,
-      "feature_id": "CCP43425",
-      "type": "missense_variant",
-      "nucleotide_change": "c.263A>G",
-      "protein_change": "p.Lys88Arg",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "streptomycin",
-          "who_confidence": "Assoc w R"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Lys88Arg",
-      "locus_tag": "Rv0682",
-      "gene": "rpsL",
-      "drugs": [
-        {
-          "type": "drug",
-          "drug": "streptomycin",
-          "confers": "resistance",
-          "who confidence": "Assoc w R"
-        }
-      ],
-      "gene_associated_drugs": ["streptomycin"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 2155168,
-      "ref": "C",
-      "alt": "G",
-      "depth": 152,
-      "freq": 1.0,
-      "feature_id": "CCP44675",
-      "type": "missense_variant",
-      "nucleotide_change": "c.944G>C",
-      "protein_change": "p.Ser315Thr",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "isoniazid",
-          "who_confidence": "Assoc w R"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Ser315Thr",
-      "locus_tag": "Rv1908c",
-      "gene": "katG",
-      "drugs": [
-        {
-          "type": "drug",
-          "drug": "isoniazid",
-          "confers": "resistance",
-          "who confidence": "Assoc w R"
-        }
-      ],
-      "gene_associated_drugs": ["isoniazid"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 4407686,
-      "ref": "C",
-      "alt": "A",
-      "depth": 221,
-      "freq": 1.0,
-      "feature_id": "CCP46748",
-      "type": "stop_gained",
-      "nucleotide_change": "c.517G>T",
-      "protein_change": "p.Glu173*",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "streptomycin",
-          "who_confidence": "Assoc w R - interim"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Glu173*",
-      "locus_tag": "Rv3919c",
-      "gene": "gid",
-      "drugs": [
-        {
-          "type": "drug",
-          "drug": "streptomycin",
-          "literature": "https://www.who.int/publications/i/item/9789240028173",
-          "confers": "resistance",
-          "who confidence": "Assoc w R - interim"
-        }
-      ],
-      "gene_associated_drugs": ["streptomycin"]
-    }
-  ],
-  "other_variants": [
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 7296,
-      "ref": "G",
-      "alt": "T",
-      "depth": 160,
-      "freq": 0.1125,
-      "feature_id": "CCP42728",
-      "type": "upstream_gene_variant",
-      "nucleotide_change": "c.-6G>T",
-      "protein_change": "",
-      "alternate_consequences": [],
-      "change": "c.-6G>T",
-      "locus_tag": "Rv0006",
-      "gene": "gyrA",
-      "gene_associated_drugs": [
-        "fluoroquinolones",
-        "moxifloxacin",
-        "levofloxacin",
-        "ciprofloxacin",
-        "ofloxacin"
-      ]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 7362,
-      "ref": "G",
-      "alt": "C",
-      "depth": 181,
-      "freq": 0.994475138121547,
-      "feature_id": "CCP42728",
-      "type": "missense_variant",
-      "nucleotide_change": "c.61G>C",
-      "protein_change": "p.Glu21Gln",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "moxifloxacin",
-          "who_confidence": "Not assoc w R"
+            "fraction": 0.9989017023613399,
+            "lineage": "lineage2",
+            "family": "East-Asian",
+            "rd": "RD105",
+            "support": [
+                {
+                    "id": "lineage2",
+                    "chrom": "NC_000962.3",
+                    "pos": 39158,
+                    "target_allele_count": 196,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2",
+                    "chrom": "NC_000962.3",
+                    "pos": 282892,
+                    "target_allele_count": 102,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2",
+                    "chrom": "NC_000962.3",
+                    "pos": 497491,
+                    "target_allele_count": 218,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2",
+                    "chrom": "NC_000962.3",
+                    "pos": 811753,
+                    "target_allele_count": 136,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2",
+                    "chrom": "NC_000962.3",
+                    "pos": 1102468,
+                    "target_allele_count": 167,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2",
+                    "chrom": "NC_000962.3",
+                    "pos": 1317655,
+                    "target_allele_count": 249,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2",
+                    "chrom": "NC_000962.3",
+                    "pos": 1577241,
+                    "target_allele_count": 169,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2",
+                    "chrom": "NC_000962.3",
+                    "pos": 1980652,
+                    "target_allele_count": 172,
+                    "other_allele_count": 1,
+                    "target_allele_percent": 99.42196531791907
+                },
+                {
+                    "id": "lineage2",
+                    "chrom": "NC_000962.3",
+                    "pos": 4254431,
+                    "target_allele_count": 165,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2",
+                    "chrom": "NC_000962.3",
+                    "pos": 4308395,
+                    "target_allele_count": 245,
+                    "other_allele_count": 1,
+                    "target_allele_percent": 99.59349593495935
+                }
+            ]
         },
         {
-          "type": "who_confidence",
-          "drug": "levofloxacin",
-          "who_confidence": "Not assoc w R"
+            "fraction": 0.998792270531401,
+            "lineage": "lineage2.2.1",
+            "family": "East-Asian (Beijing)",
+            "rd": "RD105;RD207;RD181",
+            "support": [
+                {
+                    "id": "lineage2.2.1",
+                    "chrom": "NC_000962.3",
+                    "pos": 135329,
+                    "target_allele_count": 171,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2.2.1",
+                    "chrom": "NC_000962.3",
+                    "pos": 163705,
+                    "target_allele_count": 112,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2.2.1",
+                    "chrom": "NC_000962.3",
+                    "pos": 215977,
+                    "target_allele_count": 168,
+                    "other_allele_count": 1,
+                    "target_allele_percent": 99.40828402366864
+                },
+                {
+                    "id": "lineage2.2.1",
+                    "chrom": "NC_000962.3",
+                    "pos": 533547,
+                    "target_allele_count": 119,
+                    "other_allele_count": 1,
+                    "target_allele_percent": 99.16666666666667
+                },
+                {
+                    "id": "lineage2.2.1",
+                    "chrom": "NC_000962.3",
+                    "pos": 797736,
+                    "target_allele_count": 236,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2.2.1",
+                    "chrom": "NC_000962.3",
+                    "pos": 1906078,
+                    "target_allele_count": 148,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2.2.1",
+                    "chrom": "NC_000962.3",
+                    "pos": 2078246,
+                    "target_allele_count": 149,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2.2.1",
+                    "chrom": "NC_000962.3",
+                    "pos": 2825581,
+                    "target_allele_count": 144,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2.2.1",
+                    "chrom": "NC_000962.3",
+                    "pos": 3498198,
+                    "target_allele_count": 177,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2.2.1",
+                    "chrom": "NC_000962.3",
+                    "pos": 4158493,
+                    "target_allele_count": 230,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                }
+            ]
+        },
+        {
+            "fraction": 0.9980324643384161,
+            "lineage": "lineage2.2",
+            "family": "East-Asian (Beijing)",
+            "rd": "RD105;RD207",
+            "support": [
+                {
+                    "id": "lineage2.2",
+                    "chrom": "NC_000962.3",
+                    "pos": 195682,
+                    "target_allele_count": 201,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2.2",
+                    "chrom": "NC_000962.3",
+                    "pos": 363464,
+                    "target_allele_count": 240,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2.2",
+                    "chrom": "NC_000962.3",
+                    "pos": 465300,
+                    "target_allele_count": 154,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2.2",
+                    "chrom": "NC_000962.3",
+                    "pos": 892416,
+                    "target_allele_count": 160,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2.2",
+                    "chrom": "NC_000962.3",
+                    "pos": 1288698,
+                    "target_allele_count": 212,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2.2",
+                    "chrom": "NC_000962.3",
+                    "pos": 1695037,
+                    "target_allele_count": 243,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2.2",
+                    "chrom": "NC_000962.3",
+                    "pos": 1849051,
+                    "target_allele_count": 249,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                },
+                {
+                    "id": "lineage2.2",
+                    "chrom": "NC_000962.3",
+                    "pos": 2112832,
+                    "target_allele_count": 187,
+                    "other_allele_count": 2,
+                    "target_allele_percent": 98.94179894179894
+                },
+                {
+                    "id": "lineage2.2",
+                    "chrom": "NC_000962.3",
+                    "pos": 2202500,
+                    "target_allele_count": 192,
+                    "other_allele_count": 2,
+                    "target_allele_percent": 98.96907216494846
+                },
+                {
+                    "id": "lineage2.2",
+                    "chrom": "NC_000962.3",
+                    "pos": 2505085,
+                    "target_allele_count": 191,
+                    "other_allele_count": 0,
+                    "target_allele_percent": 100.0
+                }
+            ]
         }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Glu21Gln",
-      "locus_tag": "Rv0006",
-      "gene": "gyrA",
-      "gene_associated_drugs": [
-        "fluoroquinolones",
-        "moxifloxacin",
-        "levofloxacin",
-        "ciprofloxacin",
-        "ofloxacin"
-      ]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 7585,
-      "ref": "G",
-      "alt": "C",
-      "depth": 212,
-      "freq": 1.0,
-      "feature_id": "CCP42728",
-      "type": "missense_variant",
-      "nucleotide_change": "c.284G>C",
-      "protein_change": "p.Ser95Thr",
-      "annotation": [
+    ],
+    "main_lineage": "lineage2",
+    "sub_lineage": "lineage2.2.1",
+    "spoligotype": null,
+    "drtype": "MDR-TB",
+    "dr_variants": [
         {
-          "type": "who_confidence",
-          "drug": "levofloxacin",
-          "who_confidence": "Not assoc w R"
+            "chrom": "NC_000962.3",
+            "pos": 761104,
+            "ref": "TCATGGA",
+            "alt": "T",
+            "depth": 165,
+            "freq": 0.9878787878787879,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 90,
+            "reverse_reads": 73,
+            "sv_len": null,
+            "gene_id": "Rv0667",
+            "gene_name": "rpoB",
+            "feature_id": "CCP43410",
+            "type": "conservative_inframe_deletion",
+            "change": "c.1300_1305delATGGAC",
+            "nucleotide_change": "c.1300_1305delATGGAC",
+            "protein_change": "p.Met434_Asp435del",
+            "annotation": [
+                {
+                    "type": "drug_resistance",
+                    "drug": "rifampicin",
+                    "original_mutation": "RRDR non-silent",
+                    "confidence": "Assoc w R - Interim",
+                    "source": "WHO catalogue v2",
+                    "comment": "Expert rule: Non-silent variants in RRDR of rpoB"
+                },
+                {
+                    "type": "drug_resistance",
+                    "drug": "rifampicin",
+                    "original_mutation": "c.1300_1305delATGGAC",
+                    "confidence": "",
+                    "source": "tbdb",
+                    "comment": "Mutation from literature"
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv0667",
+                    "gene_name": "rpoB",
+                    "feature_id": "CCP43410",
+                    "type": "conservative_inframe_deletion",
+                    "nucleotide_change": "c.1300_1305delATGGAC",
+                    "protein_change": "p.Met434_Asp435del",
+                    "annotation": [
+                        {
+                            "type": "drug_resistance",
+                            "drug": "rifampicin",
+                            "original_mutation": "RRDR non-silent",
+                            "confidence": "Assoc w R - Interim",
+                            "source": "WHO catalogue v2",
+                            "comment": "Expert rule: Non-silent variants in RRDR of rpoB"
+                        },
+                        {
+                            "type": "drug_resistance",
+                            "drug": "rifampicin",
+                            "original_mutation": "c.1300_1305delATGGAC",
+                            "confidence": "",
+                            "source": "tbdb",
+                            "comment": "Mutation from literature"
+                        },
+                        {
+                            "type": "drug_resistance",
+                            "drug": "rifampicin",
+                            "original_mutation": "p.Met434_Asp435del",
+                            "confidence": "Assoc w R - Interim",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "drugs": [
+                {
+                    "type": "drug_resistance",
+                    "drug": "rifampicin",
+                    "original_mutation": "RRDR non-silent",
+                    "confidence": "Assoc w R - Interim",
+                    "source": "WHO catalogue v2",
+                    "comment": "Expert rule: Non-silent variants in RRDR of rpoB"
+                },
+                {
+                    "type": "drug_resistance",
+                    "drug": "rifampicin",
+                    "original_mutation": "c.1300_1305delATGGAC",
+                    "confidence": "",
+                    "source": "tbdb",
+                    "comment": "Mutation from literature"
+                }
+            ],
+            "locus_tag": "Rv0667",
+            "gene_associated_drugs": [
+                "rifampicin"
+            ]
         },
         {
-          "type": "who_confidence",
-          "drug": "moxifloxacin",
-          "who_confidence": "Not assoc w R"
+            "chrom": "NC_000962.3",
+            "pos": 781822,
+            "ref": "A",
+            "alt": "G",
+            "depth": 240,
+            "freq": 0.9875,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 101,
+            "reverse_reads": 136,
+            "sv_len": null,
+            "gene_id": "Rv0682",
+            "gene_name": "rpsL",
+            "feature_id": "CCP43425",
+            "type": "missense_variant",
+            "change": "p.Lys88Arg",
+            "nucleotide_change": "c.263A>G",
+            "protein_change": "p.Lys88Arg",
+            "annotation": [
+                {
+                    "type": "drug_resistance",
+                    "drug": "streptomycin",
+                    "original_mutation": "p.Lys88Arg",
+                    "confidence": "Assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv0682",
+                    "gene_name": "rpsL",
+                    "feature_id": "CCP43425",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.263A>G",
+                    "protein_change": "p.Lys88Arg",
+                    "annotation": [
+                        {
+                            "type": "drug_resistance",
+                            "drug": "streptomycin",
+                            "original_mutation": "p.Lys88Arg",
+                            "confidence": "Assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "drugs": [
+                {
+                    "type": "drug_resistance",
+                    "drug": "streptomycin",
+                    "original_mutation": "p.Lys88Arg",
+                    "confidence": "Assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "locus_tag": "Rv0682",
+            "gene_associated_drugs": [
+                "streptomycin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 2155168,
+            "ref": "C",
+            "alt": "G",
+            "depth": 154,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 72,
+            "reverse_reads": 82,
+            "sv_len": null,
+            "gene_id": "Rv1908c",
+            "gene_name": "katG",
+            "feature_id": "CCP44675",
+            "type": "missense_variant",
+            "change": "p.Ser315Thr",
+            "nucleotide_change": "c.944G>C",
+            "protein_change": "p.Ser315Thr",
+            "annotation": [
+                {
+                    "type": "drug_resistance",
+                    "drug": "isoniazid",
+                    "original_mutation": "p.Ser315Thr",
+                    "confidence": "Assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": "High-level resistance"
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv1908c",
+                    "gene_name": "katG",
+                    "feature_id": "CCP44675",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.944G>C",
+                    "protein_change": "p.Ser315Thr",
+                    "annotation": [
+                        {
+                            "type": "drug_resistance",
+                            "drug": "isoniazid",
+                            "original_mutation": "p.Ser315Thr",
+                            "confidence": "Assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": "High-level resistance"
+                        }
+                    ]
+                }
+            ],
+            "drugs": [
+                {
+                    "type": "drug_resistance",
+                    "drug": "isoniazid",
+                    "original_mutation": "p.Ser315Thr",
+                    "confidence": "Assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": "High-level resistance"
+                }
+            ],
+            "locus_tag": "Rv1908c",
+            "gene_associated_drugs": [
+                "isoniazid"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4407686,
+            "ref": "C",
+            "alt": "A",
+            "depth": 233,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 115,
+            "reverse_reads": 118,
+            "sv_len": null,
+            "gene_id": "Rv3919c",
+            "gene_name": "gid",
+            "feature_id": "CCP46748",
+            "type": "stop_gained",
+            "change": "p.Glu173*",
+            "nucleotide_change": "c.517G>T",
+            "protein_change": "p.Glu173*",
+            "annotation": [
+                {
+                    "type": "drug_resistance",
+                    "drug": "streptomycin",
+                    "original_mutation": "LoF",
+                    "confidence": "Assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv3919c",
+                    "gene_name": "gid",
+                    "feature_id": "CCP46748",
+                    "type": "stop_gained",
+                    "nucleotide_change": "c.517G>T",
+                    "protein_change": "p.Glu173*",
+                    "annotation": [
+                        {
+                            "type": "drug_resistance",
+                            "drug": "streptomycin",
+                            "original_mutation": "LoF",
+                            "confidence": "Assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "drug_resistance",
+                            "drug": "streptomycin",
+                            "original_mutation": "p.Glu173*",
+                            "confidence": "Assoc w R - Interim",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "drugs": [
+                {
+                    "type": "drug_resistance",
+                    "drug": "streptomycin",
+                    "original_mutation": "LoF",
+                    "confidence": "Assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "locus_tag": "Rv3919c",
+            "gene_associated_drugs": [
+                "streptomycin"
+            ]
         }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Ser95Thr",
-      "locus_tag": "Rv0006",
-      "gene": "gyrA",
-      "gene_associated_drugs": [
-        "fluoroquinolones",
-        "moxifloxacin",
-        "levofloxacin",
-        "ciprofloxacin",
-        "ofloxacin"
-      ]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 9304,
-      "ref": "G",
-      "alt": "A",
-      "depth": 221,
-      "freq": 1.0,
-      "feature_id": "CCP42728",
-      "type": "missense_variant",
-      "nucleotide_change": "c.2003G>A",
-      "protein_change": "p.Gly668Asp",
-      "annotation": [
+    ],
+    "other_variants": [
         {
-          "type": "who_confidence",
-          "drug": "moxifloxacin",
-          "who_confidence": "Not assoc w R"
+            "chrom": "NC_000962.3",
+            "pos": 7362,
+            "ref": "G",
+            "alt": "C",
+            "depth": 210,
+            "freq": 0.9952380952380953,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 111,
+            "reverse_reads": 98,
+            "sv_len": null,
+            "gene_id": "Rv0006",
+            "gene_name": "gyrA",
+            "feature_id": "CCP42728",
+            "type": "missense_variant",
+            "change": "p.Glu21Gln",
+            "nucleotide_change": "c.61G>C",
+            "protein_change": "p.Glu21Gln",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "levofloxacin",
+                    "original_mutation": "p.Glu21Gln",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "moxifloxacin",
+                    "original_mutation": "p.Glu21Gln",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv0006",
+                    "gene_name": "gyrA",
+                    "feature_id": "CCP42728",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.61G>C",
+                    "protein_change": "p.Glu21Gln",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "moxifloxacin",
+                            "original_mutation": "p.Glu21Gln",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "levofloxacin",
+                            "original_mutation": "p.Glu21Gln",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv0006",
+            "gene_associated_drugs": [
+                "fluoroquinolones",
+                "moxifloxacin",
+                "levofloxacin"
+            ]
         },
         {
-          "type": "who_confidence",
-          "drug": "levofloxacin",
-          "who_confidence": "Not assoc w R"
+            "chrom": "NC_000962.3",
+            "pos": 7585,
+            "ref": "G",
+            "alt": "C",
+            "depth": 219,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 113,
+            "reverse_reads": 106,
+            "sv_len": null,
+            "gene_id": "Rv0006",
+            "gene_name": "gyrA",
+            "feature_id": "CCP42728",
+            "type": "missense_variant",
+            "change": "p.Ser95Thr",
+            "nucleotide_change": "c.284G>C",
+            "protein_change": "p.Ser95Thr",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "levofloxacin",
+                    "original_mutation": "p.Ser95Thr",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "moxifloxacin",
+                    "original_mutation": "p.Ser95Thr",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv0006",
+                    "gene_name": "gyrA",
+                    "feature_id": "CCP42728",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.284G>C",
+                    "protein_change": "p.Ser95Thr",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "levofloxacin",
+                            "original_mutation": "p.Ser95Thr",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "moxifloxacin",
+                            "original_mutation": "p.Ser95Thr",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv0006",
+            "gene_associated_drugs": [
+                "fluoroquinolones",
+                "moxifloxacin",
+                "levofloxacin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 9304,
+            "ref": "G",
+            "alt": "A",
+            "depth": 228,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 116,
+            "reverse_reads": 112,
+            "sv_len": null,
+            "gene_id": "Rv0006",
+            "gene_name": "gyrA",
+            "feature_id": "CCP42728",
+            "type": "missense_variant",
+            "change": "p.Gly668Asp",
+            "nucleotide_change": "c.2003G>A",
+            "protein_change": "p.Gly668Asp",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "levofloxacin",
+                    "original_mutation": "p.Gly668Asp",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "moxifloxacin",
+                    "original_mutation": "p.Gly668Asp",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv0006",
+                    "gene_name": "gyrA",
+                    "feature_id": "CCP42728",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.2003G>A",
+                    "protein_change": "p.Gly668Asp",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "moxifloxacin",
+                            "original_mutation": "p.Gly668Asp",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "levofloxacin",
+                            "original_mutation": "p.Gly668Asp",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv0006",
+            "gene_associated_drugs": [
+                "fluoroquinolones",
+                "moxifloxacin",
+                "levofloxacin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 491742,
+            "ref": "T",
+            "alt": "C",
+            "depth": 153,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 98,
+            "reverse_reads": 55,
+            "sv_len": null,
+            "gene_id": "Rv0407",
+            "gene_name": "fgd1",
+            "feature_id": "CCP43138",
+            "type": "synonymous_variant",
+            "change": "c.960T>C",
+            "nucleotide_change": "c.960T>C",
+            "protein_change": "p.Phe320Phe",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "delamanid",
+                    "original_mutation": "c.960T>C",
+                    "confidence": "Not assoc w R - Interim",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "clofazimine",
+                    "original_mutation": "c.960T>C",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv0407",
+                    "gene_name": "fgd1",
+                    "feature_id": "CCP43138",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.960T>C",
+                    "protein_change": "p.Phe320Phe",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "delamanid",
+                            "original_mutation": "c.960T>C",
+                            "confidence": "Not assoc w R - Interim",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "clofazimine",
+                            "original_mutation": "c.960T>C",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv0407",
+            "gene_associated_drugs": [
+                "clofazimine",
+                "delamanid",
+                "pretomanid"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 575907,
+            "ref": "C",
+            "alt": "T",
+            "depth": 256,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 138,
+            "reverse_reads": 118,
+            "sv_len": null,
+            "gene_id": "Rv0486",
+            "gene_name": "mshA",
+            "feature_id": "CCP43220",
+            "type": "missense_variant",
+            "change": "p.Ala187Val",
+            "nucleotide_change": "c.560C>T",
+            "protein_change": "p.Ala187Val",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "isoniazid",
+                    "original_mutation": "p.Ala187Val",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "ethionamide",
+                    "original_mutation": "p.Ala187Val",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv0486",
+                    "gene_name": "mshA",
+                    "feature_id": "CCP43220",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.560C>T",
+                    "protein_change": "p.Ala187Val",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "isoniazid",
+                            "original_mutation": "p.Ala187Val",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "ethionamide",
+                            "original_mutation": "p.Ala187Val",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv0486",
+            "gene_associated_drugs": [
+                "isoniazid",
+                "ethionamide"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 620625,
+            "ref": "A",
+            "alt": "G",
+            "depth": 189,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 74,
+            "reverse_reads": 115,
+            "sv_len": null,
+            "gene_id": "Rv0529",
+            "gene_name": "ccsA",
+            "feature_id": "CCP43266",
+            "type": "missense_variant",
+            "change": "p.Ile245Met",
+            "nucleotide_change": "c.735A>G",
+            "protein_change": "p.Ile245Met",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "capreomycin",
+                    "original_mutation": "p.Ile245Met",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "amikacin",
+                    "original_mutation": "p.Ile245Met",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "kanamycin",
+                    "original_mutation": "p.Ile245Met",
+                    "confidence": "Uncertain significance",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv0529",
+                    "gene_name": "ccsA",
+                    "feature_id": "CCP43266",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.735A>G",
+                    "protein_change": "p.Ile245Met",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "capreomycin",
+                            "original_mutation": "p.Ile245Met",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "kanamycin",
+                            "original_mutation": "p.Ile245Met",
+                            "confidence": "Uncertain significance",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "amikacin",
+                            "original_mutation": "p.Ile245Met",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv0529",
+            "gene_associated_drugs": [
+                "capreomycin",
+                "amikacin",
+                "kanamycin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 657081,
+            "ref": "C",
+            "alt": "T",
+            "depth": 189,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 91,
+            "reverse_reads": 98,
+            "sv_len": null,
+            "gene_id": "Rv0565c",
+            "gene_name": "Rv0565c",
+            "feature_id": "CCP43303",
+            "type": "synonymous_variant",
+            "change": "c.390G>A",
+            "nucleotide_change": "c.390G>A",
+            "protein_change": "p.Val130Val",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "ethionamide",
+                    "original_mutation": "c.390G>A",
+                    "confidence": "Not assoc w R - Interim",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv0565c",
+                    "gene_name": "Rv0565c",
+                    "feature_id": "CCP43303",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.390G>A",
+                    "protein_change": "p.Val130Val",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "ethionamide",
+                            "original_mutation": "c.390G>A",
+                            "confidence": "Not assoc w R - Interim",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv0565c",
+            "gene_associated_drugs": [
+                "ethionamide"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 657142,
+            "ref": "C",
+            "alt": "T",
+            "depth": 203,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 120,
+            "reverse_reads": 83,
+            "sv_len": null,
+            "gene_id": "Rv0565c",
+            "gene_name": "Rv0565c",
+            "feature_id": "CCP43303",
+            "type": "missense_variant",
+            "change": "p.Arg110His",
+            "nucleotide_change": "c.329G>A",
+            "protein_change": "p.Arg110His",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "ethionamide",
+                    "original_mutation": "p.Arg110His",
+                    "confidence": "Uncertain significance",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv0565c",
+                    "gene_name": "Rv0565c",
+                    "feature_id": "CCP43303",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.329G>A",
+                    "protein_change": "p.Arg110His",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "ethionamide",
+                            "original_mutation": "p.Arg110His",
+                            "confidence": "Uncertain significance",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv0565c",
+            "gene_associated_drugs": [
+                "ethionamide"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 763031,
+            "ref": "T",
+            "alt": "C",
+            "depth": 216,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 109,
+            "reverse_reads": 107,
+            "sv_len": null,
+            "gene_id": "Rv0667",
+            "gene_name": "rpoB",
+            "feature_id": "CCP43410",
+            "type": "synonymous_variant",
+            "change": "c.3225T>C",
+            "nucleotide_change": "c.3225T>C",
+            "protein_change": "p.Ala1075Ala",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "rifampicin",
+                    "original_mutation": "c.3225T>C",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv0667",
+                    "gene_name": "rpoB",
+                    "feature_id": "CCP43410",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.3225T>C",
+                    "protein_change": "p.Ala1075Ala",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "rifampicin",
+                            "original_mutation": "c.3225T>C",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                },
+                {
+                    "gene_id": "Rv0668",
+                    "gene_name": "rpoC",
+                    "feature_id": "CCP43411",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-339T>C",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv0667",
+            "gene_associated_drugs": [
+                "rifampicin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 775639,
+            "ref": "T",
+            "alt": "C",
+            "depth": 211,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 102,
+            "reverse_reads": 109,
+            "sv_len": null,
+            "gene_id": "Rv0676c",
+            "gene_name": "mmpL5",
+            "feature_id": "CCP43419",
+            "type": "missense_variant",
+            "change": "p.Ile948Val",
+            "nucleotide_change": "c.2842A>G",
+            "protein_change": "p.Ile948Val",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "bedaquiline",
+                    "original_mutation": "p.Ile948Val",
+                    "confidence": "Not assoc w R - Interim",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "clofazimine",
+                    "original_mutation": "p.Ile948Val",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv0676c",
+                    "gene_name": "mmpL5",
+                    "feature_id": "CCP43419",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.2842A>G",
+                    "protein_change": "p.Ile948Val",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "bedaquiline",
+                            "original_mutation": "p.Ile948Val",
+                            "confidence": "Not assoc w R - Interim",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "clofazimine",
+                            "original_mutation": "p.Ile948Val",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv0676c",
+            "gene_associated_drugs": [
+                "clofazimine",
+                "bedaquiline"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 776100,
+            "ref": "G",
+            "alt": "A",
+            "depth": 205,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 87,
+            "reverse_reads": 118,
+            "sv_len": null,
+            "gene_id": "Rv0676c",
+            "gene_name": "mmpL5",
+            "feature_id": "CCP43419",
+            "type": "missense_variant",
+            "change": "p.Thr794Ile",
+            "nucleotide_change": "c.2381C>T",
+            "protein_change": "p.Thr794Ile",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "bedaquiline",
+                    "original_mutation": "p.Thr794Ile",
+                    "confidence": "Not assoc w R - Interim",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "clofazimine",
+                    "original_mutation": "p.Thr794Ile",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv0676c",
+                    "gene_name": "mmpL5",
+                    "feature_id": "CCP43419",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.2381C>T",
+                    "protein_change": "p.Thr794Ile",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "bedaquiline",
+                            "original_mutation": "p.Thr794Ile",
+                            "confidence": "Not assoc w R - Interim",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "clofazimine",
+                            "original_mutation": "p.Thr794Ile",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv0676c",
+            "gene_associated_drugs": [
+                "clofazimine",
+                "bedaquiline"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 776182,
+            "ref": "C",
+            "alt": "T",
+            "depth": 160,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 78,
+            "reverse_reads": 82,
+            "sv_len": null,
+            "gene_id": "Rv0676c",
+            "gene_name": "mmpL5",
+            "feature_id": "CCP43419",
+            "type": "missense_variant",
+            "change": "p.Asp767Asn",
+            "nucleotide_change": "c.2299G>A",
+            "protein_change": "p.Asp767Asn",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "bedaquiline",
+                    "original_mutation": "p.Asp767Asn",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "clofazimine",
+                    "original_mutation": "p.Asp767Asn",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv0676c",
+                    "gene_name": "mmpL5",
+                    "feature_id": "CCP43419",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.2299G>A",
+                    "protein_change": "p.Asp767Asn",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "bedaquiline",
+                            "original_mutation": "p.Asp767Asn",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "clofazimine",
+                            "original_mutation": "p.Asp767Asn",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv0676c",
+            "gene_associated_drugs": [
+                "clofazimine",
+                "bedaquiline"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 779615,
+            "ref": "G",
+            "alt": "C",
+            "depth": 200,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 112,
+            "reverse_reads": 88,
+            "sv_len": null,
+            "gene_id": "Rv0677c",
+            "gene_name": "mmpS5",
+            "feature_id": "CCP43420",
+            "type": "upstream_gene_variant",
+            "change": "c.-710C>G",
+            "nucleotide_change": "c.-710C>G",
+            "protein_change": "",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv0677c",
+                    "gene_name": "mmpS5",
+                    "feature_id": "CCP43420",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-710C>G",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv0677c",
+            "gene_associated_drugs": [
+                "clofazimine",
+                "bedaquiline"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 781395,
+            "ref": "T",
+            "alt": "C",
+            "depth": 228,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 100,
+            "reverse_reads": 128,
+            "sv_len": null,
+            "gene_id": "Rv0682",
+            "gene_name": "rpsL",
+            "feature_id": "CCP43425",
+            "type": "upstream_gene_variant",
+            "change": "c.-165T>C",
+            "nucleotide_change": "c.-165T>C",
+            "protein_change": "",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "streptomycin",
+                    "original_mutation": "c.-165T>C",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv0682",
+                    "gene_name": "rpsL",
+                    "feature_id": "CCP43425",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-165T>C",
+                    "protein_change": "",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "streptomycin",
+                            "original_mutation": "c.-165T>C",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv0682",
+            "gene_associated_drugs": [
+                "streptomycin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 1254562,
+            "ref": "A",
+            "alt": "G",
+            "depth": 218,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 98,
+            "reverse_reads": 120,
+            "sv_len": null,
+            "gene_id": "Rv1129c",
+            "gene_name": "Rv1129c",
+            "feature_id": "CCP43883",
+            "type": "upstream_gene_variant",
+            "change": "c.-28T>C",
+            "nucleotide_change": "c.-28T>C",
+            "protein_change": "",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "isoniazid",
+                    "original_mutation": "c.-28T>C",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "levofloxacin",
+                    "original_mutation": "c.-28T>C",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "rifampicin",
+                    "original_mutation": "c.-28T>C",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "moxifloxacin",
+                    "original_mutation": "c.-28T>C",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv1129c",
+                    "gene_name": "Rv1129c",
+                    "feature_id": "CCP43883",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-28T>C",
+                    "protein_change": "",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "isoniazid",
+                            "original_mutation": "c.-28T>C",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "rifampicin",
+                            "original_mutation": "c.-28T>C",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "levofloxacin",
+                            "original_mutation": "c.-28T>C",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "moxifloxacin",
+                            "original_mutation": "c.-28T>C",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv1129c",
+            "gene_associated_drugs": [
+                "isoniazid",
+                "rifampicin",
+                "moxifloxacin",
+                "levofloxacin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 1406760,
+            "ref": "T",
+            "alt": "TG",
+            "depth": 195,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 107,
+            "reverse_reads": 88,
+            "sv_len": null,
+            "gene_id": "Rv1258c",
+            "gene_name": "Rv1258c",
+            "feature_id": "CCP44014",
+            "type": "frameshift_variant",
+            "change": "c.580_581insC",
+            "nucleotide_change": "c.580_581insC",
+            "protein_change": "p.Glu194fs",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "streptomycin",
+                    "original_mutation": "LoF",
+                    "confidence": "Uncertain significance",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "isoniazid",
+                    "original_mutation": "LoF",
+                    "confidence": "Uncertain significance",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "pyrazinamide",
+                    "original_mutation": "LoF",
+                    "confidence": "Uncertain significance",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv1258c",
+                    "gene_name": "Rv1258c",
+                    "feature_id": "CCP44014",
+                    "type": "frameshift_variant",
+                    "nucleotide_change": "c.580_581insC",
+                    "protein_change": "p.Glu194fs",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "pyrazinamide",
+                            "original_mutation": "LoF",
+                            "confidence": "Uncertain significance",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "isoniazid",
+                            "original_mutation": "LoF",
+                            "confidence": "Uncertain significance",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "streptomycin",
+                            "original_mutation": "LoF",
+                            "confidence": "Uncertain significance",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "isoniazid",
+                            "original_mutation": "p.Glu194fs",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "pyrazinamide",
+                            "original_mutation": "p.Glu194fs",
+                            "confidence": "Uncertain significance",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "streptomycin",
+                            "original_mutation": "p.Glu194fs",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv1258c",
+            "gene_associated_drugs": [
+                "streptomycin",
+                "isoniazid",
+                "pyrazinamide"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 1416222,
+            "ref": "A",
+            "alt": "G",
+            "depth": 311,
+            "freq": 0.11254019292604502,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 20,
+            "reverse_reads": 15,
+            "sv_len": null,
+            "gene_id": "Rv1267c",
+            "gene_name": "embR",
+            "feature_id": "CCP44023",
+            "type": "missense_variant",
+            "change": "p.Phe376Leu",
+            "nucleotide_change": "c.1126T>C",
+            "protein_change": "p.Phe376Leu",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "ethambutol",
+                    "original_mutation": "p.Phe376Leu",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv1267c",
+                    "gene_name": "embR",
+                    "feature_id": "CCP44023",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.1126T>C",
+                    "protein_change": "p.Phe376Leu",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "ethambutol",
+                            "original_mutation": "p.Phe376Leu",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv1267c",
+            "gene_associated_drugs": [
+                "ethambutol"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 1416232,
+            "ref": "ACA",
+            "alt": "GCC",
+            "depth": 311,
+            "freq": 0.12218649517684887,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 20,
+            "reverse_reads": 18,
+            "sv_len": null,
+            "gene_id": "Rv1267c",
+            "gene_name": "embR",
+            "feature_id": "CCP44023",
+            "type": "missense_variant",
+            "change": "p.Cys372Gly",
+            "nucleotide_change": "c.1114_1116delTGTinsGGC",
+            "protein_change": "p.Cys372Gly",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "ethambutol",
+                    "original_mutation": "p.Cys372Gly",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv1267c",
+                    "gene_name": "embR",
+                    "feature_id": "CCP44023",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.1114_1116delTGTinsGGC",
+                    "protein_change": "p.Cys372Gly",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "ethambutol",
+                            "original_mutation": "p.Cys372Gly",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv1267c",
+            "gene_associated_drugs": [
+                "ethambutol"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 1416232,
+            "ref": "ACA",
+            "alt": "TCT",
+            "depth": 311,
+            "freq": 0.12218649517684887,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 20,
+            "reverse_reads": 18,
+            "sv_len": null,
+            "gene_id": "Rv1267c",
+            "gene_name": "embR",
+            "feature_id": "CCP44023",
+            "type": "missense_variant",
+            "change": "p.Cys372Arg",
+            "nucleotide_change": "c.1114_1116delTGTinsAGA",
+            "protein_change": "p.Cys372Arg",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "ethambutol",
+                    "original_mutation": "p.Cys372Arg",
+                    "confidence": "Uncertain significance",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv1267c",
+                    "gene_name": "embR",
+                    "feature_id": "CCP44023",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.1114_1116delTGTinsAGA",
+                    "protein_change": "p.Cys372Arg",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "ethambutol",
+                            "original_mutation": "p.Cys372Arg",
+                            "confidence": "Uncertain significance",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv1267c",
+            "gene_associated_drugs": [
+                "ethambutol"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 1471659,
+            "ref": "C",
+            "alt": "T",
+            "depth": 143,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 74,
+            "reverse_reads": 69,
+            "sv_len": null,
+            "gene_id": "EBG00000313325",
+            "gene_name": "rrs",
+            "feature_id": "EBG00000313325-1",
+            "type": "upstream_gene_variant",
+            "change": "n.-187C>T",
+            "nucleotide_change": "n.-187C>T",
+            "protein_change": "",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "EBG00000313325",
+                    "gene_name": "rrs",
+                    "feature_id": "EBG00000313325-1",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "n.-187C>T",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "EBG00000313325",
+            "gene_associated_drugs": [
+                "kanamycin",
+                "capreomycin",
+                "amikacin",
+                "streptomycin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 1834177,
+            "ref": "A",
+            "alt": "C",
+            "depth": 257,
+            "freq": 0.9922178988326849,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 111,
+            "reverse_reads": 144,
+            "sv_len": null,
+            "gene_id": "Rv1630",
+            "gene_name": "rpsA",
+            "feature_id": "CCP44394",
+            "type": "synonymous_variant",
+            "change": "c.636A>C",
+            "nucleotide_change": "c.636A>C",
+            "protein_change": "p.Arg212Arg",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "pyrazinamide",
+                    "original_mutation": "c.636A>C",
+                    "confidence": "Not assoc w R - Interim",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv1630",
+                    "gene_name": "rpsA",
+                    "feature_id": "CCP44394",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.636A>C",
+                    "protein_change": "p.Arg212Arg",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "pyrazinamide",
+                            "original_mutation": "c.636A>C",
+                            "confidence": "Not assoc w R - Interim",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv1630",
+            "gene_associated_drugs": [
+                "pyrazinamide"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 1854300,
+            "ref": "T",
+            "alt": "C",
+            "depth": 170,
+            "freq": 0.9941176470588236,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 65,
+            "reverse_reads": 104,
+            "sv_len": null,
+            "gene_id": "Rv1644",
+            "gene_name": "tsnR",
+            "feature_id": "CCP44409",
+            "type": "missense_variant",
+            "change": "p.Leu232Pro",
+            "nucleotide_change": "c.695T>C",
+            "protein_change": "p.Leu232Pro",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "linezolid",
+                    "original_mutation": "p.Leu232Pro",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv1644",
+                    "gene_name": "tsnR",
+                    "feature_id": "CCP44409",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.695T>C",
+                    "protein_change": "p.Leu232Pro",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "linezolid",
+                            "original_mutation": "p.Leu232Pro",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv1644",
+            "gene_associated_drugs": [
+                "linezolid"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 1917972,
+            "ref": "A",
+            "alt": "G",
+            "depth": 174,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 105,
+            "reverse_reads": 69,
+            "sv_len": null,
+            "gene_id": "Rv1694",
+            "gene_name": "tlyA",
+            "feature_id": "CCP44459",
+            "type": "synonymous_variant",
+            "change": "c.33A>G",
+            "nucleotide_change": "c.33A>G",
+            "protein_change": "p.Leu11Leu",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "capreomycin",
+                    "original_mutation": "c.33A>G",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv1694",
+                    "gene_name": "tlyA",
+                    "feature_id": "CCP44459",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.33A>G",
+                    "protein_change": "p.Leu11Leu",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "capreomycin",
+                            "original_mutation": "c.33A>G",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv1694",
+            "gene_associated_drugs": [
+                "capreomycin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 1931179,
+            "ref": "C",
+            "alt": "A",
+            "depth": 120,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 64,
+            "reverse_reads": 56,
+            "sv_len": null,
+            "gene_id": "Rv1704c",
+            "gene_name": "cycA",
+            "feature_id": "CCP44469",
+            "type": "missense_variant",
+            "change": "p.Arg93Leu",
+            "nucleotide_change": "c.278G>T",
+            "protein_change": "p.Arg93Leu",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv1704c",
+                    "gene_name": "cycA",
+                    "feature_id": "CCP44469",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.278G>T",
+                    "protein_change": "p.Arg93Leu",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv1704c",
+            "gene_associated_drugs": [
+                "cycloserine"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 2154724,
+            "ref": "C",
+            "alt": "A",
+            "depth": 215,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 100,
+            "reverse_reads": 115,
+            "sv_len": null,
+            "gene_id": "Rv1908c",
+            "gene_name": "katG",
+            "feature_id": "CCP44675",
+            "type": "missense_variant",
+            "change": "p.Arg463Leu",
+            "nucleotide_change": "c.1388G>T",
+            "protein_change": "p.Arg463Leu",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "isoniazid",
+                    "original_mutation": "p.Arg463Leu",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv1908c",
+                    "gene_name": "katG",
+                    "feature_id": "CCP44675",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.1388G>T",
+                    "protein_change": "p.Arg463Leu",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "isoniazid",
+                            "original_mutation": "p.Arg463Leu",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv1908c",
+            "gene_associated_drugs": [
+                "isoniazid"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 2167926,
+            "ref": "A",
+            "alt": "G",
+            "depth": 144,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 73,
+            "reverse_reads": 71,
+            "sv_len": null,
+            "gene_id": "Rv1918c",
+            "gene_name": "PPE35",
+            "feature_id": "CCP44685",
+            "type": "missense_variant",
+            "change": "p.Leu896Ser",
+            "nucleotide_change": "c.2687T>C",
+            "protein_change": "p.Leu896Ser",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "pyrazinamide",
+                    "original_mutation": "p.Leu896Ser",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv1918c",
+                    "gene_name": "PPE35",
+                    "feature_id": "CCP44685",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.2687T>C",
+                    "protein_change": "p.Leu896Ser",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "pyrazinamide",
+                            "original_mutation": "p.Leu896Ser",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv1918c",
+            "gene_associated_drugs": [
+                "pyrazinamide"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 2223293,
+            "ref": "T",
+            "alt": "C",
+            "depth": 166,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 88,
+            "reverse_reads": 78,
+            "sv_len": null,
+            "gene_id": "Rv1979c",
+            "gene_name": "Rv1979c",
+            "feature_id": "CCP44748",
+            "type": "upstream_gene_variant",
+            "change": "c.-129A>G",
+            "nucleotide_change": "c.-129A>G",
+            "protein_change": "",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "bedaquiline",
+                    "original_mutation": "c.-129A>G",
+                    "confidence": "Not assoc w R - Interim",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "clofazimine",
+                    "original_mutation": "c.-129A>G",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv1979c",
+                    "gene_name": "Rv1979c",
+                    "feature_id": "CCP44748",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-129A>G",
+                    "protein_change": "",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "bedaquiline",
+                            "original_mutation": "c.-129A>G",
+                            "confidence": "Not assoc w R - Interim",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "clofazimine",
+                            "original_mutation": "c.-129A>G",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv1979c",
+            "gene_associated_drugs": [
+                "clofazimine",
+                "bedaquiline"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 2714526,
+            "ref": "GGT",
+            "alt": "G",
+            "depth": 205,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 107,
+            "reverse_reads": 98,
+            "sv_len": null,
+            "gene_id": "Rv2416c",
+            "gene_name": "eis",
+            "feature_id": "CCP45207",
+            "type": "frameshift_variant",
+            "change": "c.805_806delAC",
+            "nucleotide_change": "c.805_806delAC",
+            "protein_change": "p.Thr269fs",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "amikacin",
+                    "original_mutation": "p.Thr269fs",
+                    "confidence": "Uncertain significance",
+                    "source": "WHO catalogue v2",
+                    "comment": "Abrogates effect of genetically linked AwR and AwRI eis mutations"
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "kanamycin",
+                    "original_mutation": "LoF",
+                    "confidence": "Uncertain significance",
+                    "source": "WHO catalogue v2",
+                    "comment": "Abrogates effect of genetically linked AwR and AwRI eis mutations"
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv2416c",
+                    "gene_name": "eis",
+                    "feature_id": "CCP45207",
+                    "type": "frameshift_variant",
+                    "nucleotide_change": "c.805_806delAC",
+                    "protein_change": "p.Thr269fs",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "amikacin",
+                            "original_mutation": "p.Thr269fs",
+                            "confidence": "Uncertain significance",
+                            "source": "WHO catalogue v2",
+                            "comment": "Abrogates effect of genetically linked AwR and AwRI eis mutations"
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "kanamycin",
+                            "original_mutation": "LoF",
+                            "confidence": "Uncertain significance",
+                            "source": "WHO catalogue v2",
+                            "comment": "Abrogates effect of genetically linked AwR and AwRI eis mutations"
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "kanamycin",
+                            "original_mutation": "p.Thr269fs",
+                            "confidence": "Uncertain significance",
+                            "source": "WHO catalogue v2",
+                            "comment": "Abrogates effect of genetically linked AwR and AwRI eis mutations"
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "amikacin",
+                            "original_mutation": "LoF",
+                            "confidence": "Uncertain significance",
+                            "source": "WHO catalogue v2",
+                            "comment": "Abrogates effect of genetically linked AwR and AwRI eis mutations"
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv2416c",
+            "gene_associated_drugs": [
+                "amikacin",
+                "kanamycin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 2784204,
+            "ref": "T",
+            "alt": "G",
+            "depth": 49,
+            "freq": 0.2857142857142857,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 7,
+            "reverse_reads": 7,
+            "sv_len": null,
+            "gene_id": "Rv2477c",
+            "gene_name": "Rv2477c",
+            "feature_id": "CCP45271",
+            "type": "upstream_gene_variant",
+            "change": "c.-162A>C",
+            "nucleotide_change": "c.-162A>C",
+            "protein_change": "",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv2477c",
+                    "gene_name": "Rv2477c",
+                    "feature_id": "CCP45271",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-162A>C",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv2477c",
+            "gene_associated_drugs": [
+                "kanamycin",
+                "rifampicin",
+                "ethambutol",
+                "streptomycin",
+                "amikacin",
+                "moxifloxacin",
+                "levofloxacin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 2784211,
+            "ref": "TC",
+            "alt": "CC",
+            "depth": 45,
+            "freq": 0.2,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 3,
+            "reverse_reads": 6,
+            "sv_len": null,
+            "gene_id": "Rv2477c",
+            "gene_name": "Rv2477c",
+            "feature_id": "CCP45271",
+            "type": "upstream_gene_variant",
+            "change": "c.-169A>G",
+            "nucleotide_change": "c.-169A>G",
+            "protein_change": "",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv2477c",
+                    "gene_name": "Rv2477c",
+                    "feature_id": "CCP45271",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-169A>G",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv2477c",
+            "gene_associated_drugs": [
+                "kanamycin",
+                "rifampicin",
+                "ethambutol",
+                "streptomycin",
+                "amikacin",
+                "moxifloxacin",
+                "levofloxacin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 2784211,
+            "ref": "TC",
+            "alt": "CG",
+            "depth": 45,
+            "freq": 0.2,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 3,
+            "reverse_reads": 6,
+            "sv_len": null,
+            "gene_id": "Rv2477c",
+            "gene_name": "Rv2477c",
+            "feature_id": "CCP45271",
+            "type": "upstream_gene_variant",
+            "change": "c.-170_-169delGAinsCG",
+            "nucleotide_change": "c.-170_-169delGAinsCG",
+            "protein_change": "",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv2477c",
+                    "gene_name": "Rv2477c",
+                    "feature_id": "CCP45271",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-170_-169delGAinsCG",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv2477c",
+            "gene_associated_drugs": [
+                "kanamycin",
+                "rifampicin",
+                "ethambutol",
+                "streptomycin",
+                "amikacin",
+                "moxifloxacin",
+                "levofloxacin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 2784211,
+            "ref": "TC",
+            "alt": "GC",
+            "depth": 45,
+            "freq": 0.2,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 3,
+            "reverse_reads": 6,
+            "sv_len": null,
+            "gene_id": "Rv2477c",
+            "gene_name": "Rv2477c",
+            "feature_id": "CCP45271",
+            "type": "upstream_gene_variant",
+            "change": "c.-169A>C",
+            "nucleotide_change": "c.-169A>C",
+            "protein_change": "",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv2477c",
+                    "gene_name": "Rv2477c",
+                    "feature_id": "CCP45271",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-169A>C",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv2477c",
+            "gene_associated_drugs": [
+                "kanamycin",
+                "rifampicin",
+                "ethambutol",
+                "streptomycin",
+                "amikacin",
+                "moxifloxacin",
+                "levofloxacin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 2784211,
+            "ref": "TC",
+            "alt": "GG",
+            "depth": 45,
+            "freq": 0.2,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 3,
+            "reverse_reads": 6,
+            "sv_len": null,
+            "gene_id": "Rv2477c",
+            "gene_name": "Rv2477c",
+            "feature_id": "CCP45271",
+            "type": "upstream_gene_variant",
+            "change": "c.-170_-169delGAinsCC",
+            "nucleotide_change": "c.-170_-169delGAinsCC",
+            "protein_change": "",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv2477c",
+                    "gene_name": "Rv2477c",
+                    "feature_id": "CCP45271",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-170_-169delGAinsCC",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv2477c",
+            "gene_associated_drugs": [
+                "kanamycin",
+                "rifampicin",
+                "ethambutol",
+                "streptomycin",
+                "amikacin",
+                "moxifloxacin",
+                "levofloxacin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 2784211,
+            "ref": "TC",
+            "alt": "TG",
+            "depth": 45,
+            "freq": 0.2,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 3,
+            "reverse_reads": 6,
+            "sv_len": null,
+            "gene_id": "Rv2477c",
+            "gene_name": "Rv2477c",
+            "feature_id": "CCP45271",
+            "type": "upstream_gene_variant",
+            "change": "c.-170G>C",
+            "nucleotide_change": "c.-170G>C",
+            "protein_change": "",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv2477c",
+                    "gene_name": "Rv2477c",
+                    "feature_id": "CCP45271",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-170G>C",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv2477c",
+            "gene_associated_drugs": [
+                "kanamycin",
+                "rifampicin",
+                "ethambutol",
+                "streptomycin",
+                "amikacin",
+                "moxifloxacin",
+                "levofloxacin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 3086788,
+            "ref": "T",
+            "alt": "C",
+            "depth": 171,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 72,
+            "reverse_reads": 99,
+            "sv_len": null,
+            "gene_id": "Rv2780",
+            "gene_name": "ald",
+            "feature_id": "CCP45579",
+            "type": "upstream_gene_variant",
+            "change": "c.-32T>C",
+            "nucleotide_change": "c.-32T>C",
+            "protein_change": "",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv2780",
+                    "gene_name": "ald",
+                    "feature_id": "CCP45579",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-32T>C",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv2780",
+            "gene_associated_drugs": [
+                "cycloserine"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 3612813,
+            "ref": "T",
+            "alt": "C",
+            "depth": 119,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 57,
+            "reverse_reads": 62,
+            "sv_len": null,
+            "gene_id": "Rv3236c",
+            "gene_name": "Rv3236c",
+            "feature_id": "CCP46055",
+            "type": "missense_variant",
+            "change": "p.Thr102Ala",
+            "nucleotide_change": "c.304A>G",
+            "protein_change": "p.Thr102Ala",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "pyrazinamide",
+                    "original_mutation": "p.Thr102Ala",
+                    "confidence": "Not assoc w R - Interim",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv3236c",
+                    "gene_name": "Rv3236c",
+                    "feature_id": "CCP46055",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.304A>G",
+                    "protein_change": "p.Thr102Ala",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "pyrazinamide",
+                            "original_mutation": "p.Thr102Ala",
+                            "confidence": "Not assoc w R - Interim",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv3236c",
+            "gene_associated_drugs": [
+                "pyrazinamide"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 3625065,
+            "ref": "T",
+            "alt": "G",
+            "depth": 129,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 73,
+            "reverse_reads": 56,
+            "sv_len": null,
+            "gene_id": "Rv3245c",
+            "gene_name": "mtrB",
+            "feature_id": "CCP46064",
+            "type": "missense_variant",
+            "change": "p.Met517Leu",
+            "nucleotide_change": "c.1549A>C",
+            "protein_change": "p.Met517Leu",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "bedaquiline",
+                    "original_mutation": "p.Met517Leu",
+                    "confidence": "Uncertain significance",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "rifampicin",
+                    "original_mutation": "p.Met517Leu",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv3245c",
+                    "gene_name": "mtrB",
+                    "feature_id": "CCP46064",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.1549A>C",
+                    "protein_change": "p.Met517Leu",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "bedaquiline",
+                            "original_mutation": "p.Met517Leu",
+                            "confidence": "Uncertain significance",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "rifampicin",
+                            "original_mutation": "p.Met517Leu",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                },
+                {
+                    "gene_id": "Rv3244c",
+                    "gene_name": "lpqB",
+                    "feature_id": "CCP46063",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-155A>C",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3245c",
+            "gene_associated_drugs": [
+                "rifampicin",
+                "bedaquiline"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 3626562,
+            "ref": "G",
+            "alt": "A",
+            "depth": 239,
+            "freq": 0.99581589958159,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 111,
+            "reverse_reads": 127,
+            "sv_len": null,
+            "gene_id": "Rv3245c",
+            "gene_name": "mtrB",
+            "feature_id": "CCP46064",
+            "type": "missense_variant",
+            "change": "p.Pro18Ser",
+            "nucleotide_change": "c.52C>T",
+            "protein_change": "p.Pro18Ser",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "bedaquiline",
+                    "original_mutation": "p.Pro18Ser",
+                    "confidence": "Uncertain significance",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "rifampicin",
+                    "original_mutation": "p.Pro18Ser",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv3245c",
+                    "gene_name": "mtrB",
+                    "feature_id": "CCP46064",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.52C>T",
+                    "protein_change": "p.Pro18Ser",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "rifampicin",
+                            "original_mutation": "p.Pro18Ser",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "bedaquiline",
+                            "original_mutation": "p.Pro18Ser",
+                            "confidence": "Uncertain significance",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv3245c",
+            "gene_associated_drugs": [
+                "rifampicin",
+                "bedaquiline"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4240413,
+            "ref": "T",
+            "alt": "G",
+            "depth": 135,
+            "freq": 0.18518518518518517,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 20,
+            "reverse_reads": 5,
+            "sv_len": null,
+            "gene_id": "Rv3793",
+            "gene_name": "embC",
+            "feature_id": "CCP46622",
+            "type": "missense_variant",
+            "change": "p.Leu184Arg",
+            "nucleotide_change": "c.551T>G",
+            "protein_change": "p.Leu184Arg",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv3793",
+                    "gene_name": "embC",
+                    "feature_id": "CCP46622",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.551T>G",
+                    "protein_change": "p.Leu184Arg",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3793",
+            "gene_associated_drugs": [
+                "ethambutol"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4242643,
+            "ref": "C",
+            "alt": "T",
+            "depth": 175,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 85,
+            "reverse_reads": 90,
+            "sv_len": null,
+            "gene_id": "Rv3793",
+            "gene_name": "embC",
+            "feature_id": "CCP46622",
+            "type": "synonymous_variant",
+            "change": "c.2781C>T",
+            "nucleotide_change": "c.2781C>T",
+            "protein_change": "p.Arg927Arg",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "ethambutol",
+                    "original_mutation": "c.2781C>T",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv3793",
+                    "gene_name": "embC",
+                    "feature_id": "CCP46622",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.2781C>T",
+                    "protein_change": "p.Arg927Arg",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "ethambutol",
+                            "original_mutation": "c.2781C>T",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                },
+                {
+                    "gene_id": "Rv3794",
+                    "gene_name": "embA",
+                    "feature_id": "CCP46623",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-590C>T",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3793",
+            "gene_associated_drugs": [
+                "ethambutol"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4243460,
+            "ref": "C",
+            "alt": "T",
+            "depth": 183,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 65,
+            "reverse_reads": 118,
+            "sv_len": null,
+            "gene_id": "Rv3794",
+            "gene_name": "embA",
+            "feature_id": "CCP46623",
+            "type": "synonymous_variant",
+            "change": "c.228C>T",
+            "nucleotide_change": "c.228C>T",
+            "protein_change": "p.Cys76Cys",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "ethambutol",
+                    "original_mutation": "c.228C>T",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv3794",
+                    "gene_name": "embA",
+                    "feature_id": "CCP46623",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.228C>T",
+                    "protein_change": "p.Cys76Cys",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "ethambutol",
+                            "original_mutation": "c.228C>T",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv3794",
+            "gene_associated_drugs": [
+                "ethambutol"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4247028,
+            "ref": "T",
+            "alt": "G",
+            "depth": 127,
+            "freq": 0.2677165354330709,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 17,
+            "reverse_reads": 17,
+            "sv_len": null,
+            "gene_id": "Rv3795",
+            "gene_name": "embB",
+            "feature_id": "CCP46624",
+            "type": "missense_variant",
+            "change": "p.Leu172Arg",
+            "nucleotide_change": "c.515T>G",
+            "protein_change": "p.Leu172Arg",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv3795",
+                    "gene_name": "embB",
+                    "feature_id": "CCP46624",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.515T>G",
+                    "protein_change": "p.Leu172Arg",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3795",
+            "gene_associated_drugs": [
+                "ethambutol"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4267647,
+            "ref": "T",
+            "alt": "C",
+            "depth": 131,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 71,
+            "reverse_reads": 60,
+            "sv_len": null,
+            "gene_id": "Rv3805c",
+            "gene_name": "aftB",
+            "feature_id": "CCP46634",
+            "type": "missense_variant",
+            "change": "p.Asp397Gly",
+            "nucleotide_change": "c.1190A>G",
+            "protein_change": "p.Asp397Gly",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "ethambutol",
+                    "original_mutation": "p.Asp397Gly",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv3805c",
+                    "gene_name": "aftB",
+                    "feature_id": "CCP46634",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.1190A>G",
+                    "protein_change": "p.Asp397Gly",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "ethambutol",
+                            "original_mutation": "p.Asp397Gly",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv3805c",
+            "gene_associated_drugs": [
+                "ethambutol"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4338595,
+            "ref": "GC",
+            "alt": "G",
+            "depth": 228,
+            "freq": 0.9956140350877193,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 95,
+            "reverse_reads": 132,
+            "sv_len": null,
+            "gene_id": "Rv3862c",
+            "gene_name": "whiB6",
+            "feature_id": "CCP46691",
+            "type": "upstream_gene_variant",
+            "change": "c.-75delG",
+            "nucleotide_change": "c.-75delG",
+            "protein_change": "",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "capreomycin",
+                    "original_mutation": "c.-75delG",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "amikacin",
+                    "original_mutation": "c.-75delG",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "kanamycin",
+                    "original_mutation": "c.-75delG",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv3862c",
+                    "gene_name": "whiB6",
+                    "feature_id": "CCP46691",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-75delG",
+                    "protein_change": "",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "capreomycin",
+                            "original_mutation": "c.-75delG",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "kanamycin",
+                            "original_mutation": "c.-75delG",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "who_confidence",
+                            "drug": "amikacin",
+                            "original_mutation": "c.-75delG",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv3862c",
+            "gene_associated_drugs": [
+                "capreomycin",
+                "amikacin",
+                "kanamycin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4338732,
+            "ref": "G",
+            "alt": "A",
+            "depth": 193,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 92,
+            "reverse_reads": 101,
+            "sv_len": null,
+            "gene_id": "Rv3862c",
+            "gene_name": "whiB6",
+            "feature_id": "CCP46691",
+            "type": "upstream_gene_variant",
+            "change": "c.-211C>T",
+            "nucleotide_change": "c.-211C>T",
+            "protein_change": "",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv3862c",
+                    "gene_name": "whiB6",
+                    "feature_id": "CCP46691",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-211C>T",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3862c",
+            "gene_associated_drugs": [
+                "capreomycin",
+                "amikacin",
+                "kanamycin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4407588,
+            "ref": "T",
+            "alt": "C",
+            "depth": 243,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 120,
+            "reverse_reads": 123,
+            "sv_len": null,
+            "gene_id": "Rv3919c",
+            "gene_name": "gid",
+            "feature_id": "CCP46748",
+            "type": "synonymous_variant",
+            "change": "c.615A>G",
+            "nucleotide_change": "c.615A>G",
+            "protein_change": "p.Ala205Ala",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "streptomycin",
+                    "original_mutation": "c.615A>G",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv3919c",
+                    "gene_name": "gid",
+                    "feature_id": "CCP46748",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.615A>G",
+                    "protein_change": "p.Ala205Ala",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "streptomycin",
+                            "original_mutation": "c.615A>G",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv3919c",
+            "gene_associated_drugs": [
+                "streptomycin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4407927,
+            "ref": "T",
+            "alt": "G",
+            "depth": 251,
+            "freq": 0.9960159362549801,
+            "sv": false,
+            "filter": "pass",
+            "forward_reads": 114,
+            "reverse_reads": 136,
+            "sv_len": null,
+            "gene_id": "Rv3919c",
+            "gene_name": "gid",
+            "feature_id": "CCP46748",
+            "type": "missense_variant",
+            "change": "p.Glu92Asp",
+            "nucleotide_change": "c.276A>C",
+            "protein_change": "p.Glu92Asp",
+            "annotation": [
+                {
+                    "type": "who_confidence",
+                    "drug": "streptomycin",
+                    "original_mutation": "p.Glu92Asp",
+                    "confidence": "Not assoc w R",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv3919c",
+                    "gene_name": "gid",
+                    "feature_id": "CCP46748",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.276A>C",
+                    "protein_change": "p.Glu92Asp",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "streptomycin",
+                            "original_mutation": "p.Glu92Asp",
+                            "confidence": "Not assoc w R",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "locus_tag": "Rv3919c",
+            "gene_associated_drugs": [
+                "streptomycin"
+            ]
         }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Gly668Asp",
-      "locus_tag": "Rv0006",
-      "gene": "gyrA",
-      "gene_associated_drugs": [
-        "fluoroquinolones",
-        "moxifloxacin",
-        "levofloxacin",
-        "ciprofloxacin",
-        "ofloxacin"
-      ]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 9653,
-      "ref": "C",
-      "alt": "A",
-      "depth": 160,
-      "freq": 0.1625,
-      "feature_id": "CCP42728",
-      "type": "synonymous_variant",
-      "nucleotide_change": "c.2352C>A",
-      "protein_change": "p.Ile784Ile",
-      "alternate_consequences": [],
-      "change": "c.2352C>A",
-      "locus_tag": "Rv0006",
-      "gene": "gyrA",
-      "gene_associated_drugs": [
-        "fluoroquinolones",
-        "moxifloxacin",
-        "levofloxacin",
-        "ciprofloxacin",
-        "ofloxacin"
-      ]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 9675,
-      "ref": "C",
-      "alt": "A",
-      "depth": 139,
-      "freq": 0.11510791366906475,
-      "feature_id": "CCP42728",
-      "type": "missense_variant",
-      "nucleotide_change": "c.2374C>A",
-      "protein_change": "p.Arg792Ser",
-      "alternate_consequences": [],
-      "change": "p.Arg792Ser",
-      "locus_tag": "Rv0006",
-      "gene": "gyrA",
-      "gene_associated_drugs": [
-        "fluoroquinolones",
-        "moxifloxacin",
-        "levofloxacin",
-        "ciprofloxacin",
-        "ofloxacin"
-      ]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 491742,
-      "ref": "T",
-      "alt": "C",
-      "depth": 149,
-      "freq": 1.0,
-      "feature_id": "CCP43138",
-      "type": "synonymous_variant",
-      "nucleotide_change": "c.960T>C",
-      "protein_change": "p.Phe320Phe",
-      "alternate_consequences": [],
-      "change": "c.960T>C",
-      "locus_tag": "Rv0407",
-      "gene": "fgd1",
-      "gene_associated_drugs": ["delamanid"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 575907,
-      "ref": "C",
-      "alt": "T",
-      "depth": 252,
-      "freq": 1.0,
-      "feature_id": "CCP43220",
-      "type": "missense_variant",
-      "nucleotide_change": "c.560C>T",
-      "protein_change": "p.Ala187Val",
-      "annotation": [
+    ],
+    "qc_fail_variants": [
         {
-          "type": "who_confidence",
-          "drug": "isoniazid",
-          "who_confidence": "Not assoc w R"
+            "chrom": "NC_000962.3",
+            "pos": 7296,
+            "ref": "G",
+            "alt": "T",
+            "depth": 172,
+            "freq": 0.12790697674418605,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 0,
+            "reverse_reads": 22,
+            "sv_len": null,
+            "gene_id": "Rv0006",
+            "gene_name": "gyrA",
+            "feature_id": "CCP42728",
+            "type": "upstream_gene_variant",
+            "change": "c.-6G>T",
+            "nucleotide_change": "c.-6G>T",
+            "protein_change": "",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv0006",
+                    "gene_name": "gyrA",
+                    "feature_id": "CCP42728",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-6G>T",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv0006",
+            "gene_associated_drugs": [
+                "fluoroquinolones",
+                "moxifloxacin",
+                "levofloxacin"
+            ]
         },
         {
-          "type": "who_confidence",
-          "drug": "ethionamide",
-          "who_confidence": "Uncertain significance"
+            "chrom": "NC_000962.3",
+            "pos": 9653,
+            "ref": "C",
+            "alt": "A",
+            "depth": 187,
+            "freq": 0.22459893048128343,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 42,
+            "reverse_reads": 0,
+            "sv_len": null,
+            "gene_id": "Rv0006",
+            "gene_name": "gyrA",
+            "feature_id": "CCP42728",
+            "type": "synonymous_variant",
+            "change": "c.2352C>A",
+            "nucleotide_change": "c.2352C>A",
+            "protein_change": "p.Ile784Ile",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv0006",
+                    "gene_name": "gyrA",
+                    "feature_id": "CCP42728",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.2352C>A",
+                    "protein_change": "p.Ile784Ile",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv0006",
+            "gene_associated_drugs": [
+                "fluoroquinolones",
+                "moxifloxacin",
+                "levofloxacin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 9675,
+            "ref": "C",
+            "alt": "A",
+            "depth": 154,
+            "freq": 0.11688311688311688,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 18,
+            "reverse_reads": 0,
+            "sv_len": null,
+            "gene_id": "Rv0006",
+            "gene_name": "gyrA",
+            "feature_id": "CCP42728",
+            "type": "missense_variant",
+            "change": "p.Arg792Ser",
+            "nucleotide_change": "c.2374C>A",
+            "protein_change": "p.Arg792Ser",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv0006",
+                    "gene_name": "gyrA",
+                    "feature_id": "CCP42728",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.2374C>A",
+                    "protein_change": "p.Arg792Ser",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv0006",
+            "gene_associated_drugs": [
+                "fluoroquinolones",
+                "moxifloxacin",
+                "levofloxacin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 576628,
+            "ref": "G",
+            "alt": "C",
+            "depth": 125,
+            "freq": 0.12,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 15,
+            "reverse_reads": 0,
+            "sv_len": null,
+            "gene_id": "Rv0486",
+            "gene_name": "mshA",
+            "feature_id": "CCP43220",
+            "type": "synonymous_variant",
+            "change": "c.1281G>C",
+            "nucleotide_change": "c.1281G>C",
+            "protein_change": "p.Thr427Thr",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv0486",
+                    "gene_name": "mshA",
+                    "feature_id": "CCP43220",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.1281G>C",
+                    "protein_change": "p.Thr427Thr",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv0486",
+            "gene_associated_drugs": [
+                "isoniazid",
+                "ethionamide"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 576631,
+            "ref": "C",
+            "alt": "A",
+            "depth": 127,
+            "freq": 0.12598425196850394,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 16,
+            "reverse_reads": 0,
+            "sv_len": null,
+            "gene_id": "Rv0486",
+            "gene_name": "mshA",
+            "feature_id": "CCP43220",
+            "type": "missense_variant",
+            "change": "p.Phe428Leu",
+            "nucleotide_change": "c.1284C>A",
+            "protein_change": "p.Phe428Leu",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv0486",
+                    "gene_name": "mshA",
+                    "feature_id": "CCP43220",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.1284C>A",
+                    "protein_change": "p.Phe428Leu",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv0486",
+            "gene_associated_drugs": [
+                "isoniazid",
+                "ethionamide"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 761143,
+            "ref": "A",
+            "alt": "C",
+            "depth": 178,
+            "freq": 0.12359550561797752,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 1,
+            "reverse_reads": 21,
+            "sv_len": null,
+            "gene_id": "Rv0667",
+            "gene_name": "rpoB",
+            "feature_id": "CCP43410",
+            "type": "missense_variant",
+            "change": "p.Lys446Thr",
+            "nucleotide_change": "c.1337A>C",
+            "protein_change": "p.Lys446Thr",
+            "annotation": [
+                {
+                    "type": "drug_resistance",
+                    "drug": "rifampicin",
+                    "original_mutation": "RRDR non-silent",
+                    "confidence": "Assoc w R - Interim",
+                    "source": "WHO catalogue v2",
+                    "comment": "Expert rule: Non-silent variants in RRDR of rpoB"
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv0667",
+                    "gene_name": "rpoB",
+                    "feature_id": "CCP43410",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.1337A>C",
+                    "protein_change": "p.Lys446Thr",
+                    "annotation": [
+                        {
+                            "type": "drug_resistance",
+                            "drug": "rifampicin",
+                            "original_mutation": "RRDR non-silent",
+                            "confidence": "Assoc w R - Interim",
+                            "source": "WHO catalogue v2",
+                            "comment": "Expert rule: Non-silent variants in RRDR of rpoB"
+                        },
+                        {
+                            "type": "drug_resistance",
+                            "drug": "rifampicin",
+                            "original_mutation": "p.Lys446Thr",
+                            "confidence": "Assoc w R - Interim",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        }
+                    ]
+                }
+            ],
+            "drugs": [
+                {
+                    "type": "drug_resistance",
+                    "drug": "rifampicin",
+                    "original_mutation": "RRDR non-silent",
+                    "confidence": "Assoc w R - Interim",
+                    "source": "WHO catalogue v2",
+                    "comment": "Expert rule: Non-silent variants in RRDR of rpoB"
+                }
+            ],
+            "locus_tag": "Rv0667",
+            "gene_associated_drugs": [
+                "rifampicin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 764546,
+            "ref": "G",
+            "alt": "C",
+            "depth": 147,
+            "freq": 0.14285714285714285,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 20,
+            "reverse_reads": 1,
+            "sv_len": null,
+            "gene_id": "Rv0668",
+            "gene_name": "rpoC",
+            "feature_id": "CCP43411",
+            "type": "missense_variant",
+            "change": "p.Gly393Arg",
+            "nucleotide_change": "c.1177G>C",
+            "protein_change": "p.Gly393Arg",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv0668",
+                    "gene_name": "rpoC",
+                    "feature_id": "CCP43411",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.1177G>C",
+                    "protein_change": "p.Gly393Arg",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv0668",
+            "gene_associated_drugs": [
+                "rifampicin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 777898,
+            "ref": "C",
+            "alt": "A",
+            "depth": 173,
+            "freq": 0.14450867052023122,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 25,
+            "reverse_reads": 0,
+            "sv_len": null,
+            "gene_id": "Rv0676c",
+            "gene_name": "mmpL5",
+            "feature_id": "CCP43419",
+            "type": "missense_variant",
+            "change": "p.Asp195Tyr",
+            "nucleotide_change": "c.583G>T",
+            "protein_change": "p.Asp195Tyr",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv0676c",
+                    "gene_name": "mmpL5",
+                    "feature_id": "CCP43419",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.583G>T",
+                    "protein_change": "p.Asp195Tyr",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv0676c",
+            "gene_associated_drugs": [
+                "clofazimine",
+                "bedaquiline"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 1304938,
+            "ref": "G",
+            "alt": "T",
+            "depth": 192,
+            "freq": 0.11458333333333333,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 0,
+            "reverse_reads": 22,
+            "sv_len": null,
+            "gene_id": "Rv1173",
+            "gene_name": "fbiC",
+            "feature_id": "CCP43929",
+            "type": "stop_gained",
+            "change": "p.Glu670*",
+            "nucleotide_change": "c.2008G>T",
+            "protein_change": "p.Glu670*",
+            "annotation": [
+                {
+                    "type": "drug_resistance",
+                    "drug": "pretomanid",
+                    "original_mutation": "LoF",
+                    "confidence": "Assoc w R - Interim",
+                    "source": "WHO catalogue v2",
+                    "comment": "Confers DLM-PMD cross-resistance"
+                },
+                {
+                    "type": "drug_resistance",
+                    "drug": "delamanid",
+                    "original_mutation": "LoF",
+                    "confidence": "Assoc w R - Interim",
+                    "source": "WHO catalogue v2",
+                    "comment": "Confers DLM-PMD cross-resistance"
+                },
+                {
+                    "type": "who_confidence",
+                    "drug": "clofazimine",
+                    "original_mutation": "LoF",
+                    "confidence": "Uncertain significance",
+                    "source": "WHO catalogue v2",
+                    "comment": ""
+                }
+            ],
+            "consequences": [
+                {
+                    "gene_id": "Rv1173",
+                    "gene_name": "fbiC",
+                    "feature_id": "CCP43929",
+                    "type": "stop_gained",
+                    "nucleotide_change": "c.2008G>T",
+                    "protein_change": "p.Glu670*",
+                    "annotation": [
+                        {
+                            "type": "who_confidence",
+                            "drug": "clofazimine",
+                            "original_mutation": "LoF",
+                            "confidence": "Uncertain significance",
+                            "source": "WHO catalogue v2",
+                            "comment": ""
+                        },
+                        {
+                            "type": "drug_resistance",
+                            "drug": "pretomanid",
+                            "original_mutation": "LoF",
+                            "confidence": "Assoc w R - Interim",
+                            "source": "WHO catalogue v2",
+                            "comment": "Confers DLM-PMD cross-resistance"
+                        },
+                        {
+                            "type": "drug_resistance",
+                            "drug": "delamanid",
+                            "original_mutation": "LoF",
+                            "confidence": "Assoc w R - Interim",
+                            "source": "WHO catalogue v2",
+                            "comment": "Confers DLM-PMD cross-resistance"
+                        }
+                    ]
+                }
+            ],
+            "drugs": [
+                {
+                    "type": "drug_resistance",
+                    "drug": "pretomanid",
+                    "original_mutation": "LoF",
+                    "confidence": "Assoc w R - Interim",
+                    "source": "WHO catalogue v2",
+                    "comment": "Confers DLM-PMD cross-resistance"
+                },
+                {
+                    "type": "drug_resistance",
+                    "drug": "delamanid",
+                    "original_mutation": "LoF",
+                    "confidence": "Assoc w R - Interim",
+                    "source": "WHO catalogue v2",
+                    "comment": "Confers DLM-PMD cross-resistance"
+                }
+            ],
+            "locus_tag": "Rv1173",
+            "gene_associated_drugs": [
+                "clofazimine",
+                "delamanid",
+                "pretomanid"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 1673558,
+            "ref": "A",
+            "alt": "C",
+            "depth": 135,
+            "freq": 0.1111111111111111,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 15,
+            "reverse_reads": 0,
+            "sv_len": null,
+            "gene_id": "Rv1484",
+            "gene_name": "inhA",
+            "feature_id": "CCP44244",
+            "type": "upstream_gene_variant",
+            "change": "c.-644A>C",
+            "nucleotide_change": "c.-644A>C",
+            "protein_change": "",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv1484",
+                    "gene_name": "inhA",
+                    "feature_id": "CCP44244",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-644A>C",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv1484",
+            "gene_associated_drugs": [
+                "isoniazid",
+                "ethionamide"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 2784199,
+            "ref": "G",
+            "alt": "C",
+            "depth": 54,
+            "freq": 0.14814814814814814,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 8,
+            "reverse_reads": 0,
+            "sv_len": null,
+            "gene_id": "Rv2477c",
+            "gene_name": "Rv2477c",
+            "feature_id": "CCP45271",
+            "type": "upstream_gene_variant",
+            "change": "c.-157C>G",
+            "nucleotide_change": "c.-157C>G",
+            "protein_change": "",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv2477c",
+                    "gene_name": "Rv2477c",
+                    "feature_id": "CCP45271",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-157C>G",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv2477c",
+            "gene_associated_drugs": [
+                "kanamycin",
+                "rifampicin",
+                "ethambutol",
+                "streptomycin",
+                "amikacin",
+                "moxifloxacin",
+                "levofloxacin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 2784617,
+            "ref": "A",
+            "alt": "G",
+            "depth": 4,
+            "freq": 1.0,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 2,
+            "reverse_reads": 2,
+            "sv_len": null,
+            "gene_id": "Rv2477c",
+            "gene_name": "Rv2477c",
+            "feature_id": "CCP45271",
+            "type": "upstream_gene_variant",
+            "change": "c.-575T>C",
+            "nucleotide_change": "c.-575T>C",
+            "protein_change": "",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv2477c",
+                    "gene_name": "Rv2477c",
+                    "feature_id": "CCP45271",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-575T>C",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv2477c",
+            "gene_associated_drugs": [
+                "kanamycin",
+                "rifampicin",
+                "ethambutol",
+                "streptomycin",
+                "amikacin",
+                "moxifloxacin",
+                "levofloxacin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 3339726,
+            "ref": "A",
+            "alt": "T",
+            "depth": 100,
+            "freq": 0.14,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 2,
+            "reverse_reads": 12,
+            "sv_len": null,
+            "gene_id": "Rv2983",
+            "gene_name": "fbiD",
+            "feature_id": "CCP45788",
+            "type": "synonymous_variant",
+            "change": "c.609A>T",
+            "nucleotide_change": "c.609A>T",
+            "protein_change": "p.Val203Val",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv2983",
+                    "gene_name": "fbiD",
+                    "feature_id": "CCP45788",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.609A>T",
+                    "protein_change": "p.Val203Val",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv2983",
+            "gene_associated_drugs": [
+                "clofazimine",
+                "delamanid",
+                "pretomanid"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 3339744,
+            "ref": "A",
+            "alt": "T",
+            "depth": 42,
+            "freq": 0.19047619047619047,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 0,
+            "reverse_reads": 8,
+            "sv_len": null,
+            "gene_id": "Rv2983",
+            "gene_name": "fbiD",
+            "feature_id": "CCP45788",
+            "type": "synonymous_variant",
+            "change": "c.627A>T",
+            "nucleotide_change": "c.627A>T",
+            "protein_change": "p.Arg209Arg",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv2983",
+                    "gene_name": "fbiD",
+                    "feature_id": "CCP45788",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.627A>T",
+                    "protein_change": "p.Arg209Arg",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv2983",
+            "gene_associated_drugs": [
+                "clofazimine",
+                "delamanid",
+                "pretomanid"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 3339750,
+            "ref": "C",
+            "alt": "G",
+            "depth": 63,
+            "freq": 0.12698412698412698,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 1,
+            "reverse_reads": 7,
+            "sv_len": null,
+            "gene_id": "Rv2983",
+            "gene_name": "fbiD",
+            "feature_id": "CCP45788",
+            "type": "synonymous_variant",
+            "change": "c.633C>G",
+            "nucleotide_change": "c.633C>G",
+            "protein_change": "p.Val211Val",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv2983",
+                    "gene_name": "fbiD",
+                    "feature_id": "CCP45788",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.633C>G",
+                    "protein_change": "p.Val211Val",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv2983",
+            "gene_associated_drugs": [
+                "clofazimine",
+                "delamanid",
+                "pretomanid"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 3568425,
+            "ref": "A",
+            "alt": "C",
+            "depth": 125,
+            "freq": 0.144,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 1,
+            "reverse_reads": 17,
+            "sv_len": null,
+            "gene_id": "Rv3197A",
+            "gene_name": "whiB7",
+            "feature_id": "CCP46011",
+            "type": "synonymous_variant",
+            "change": "c.255T>G",
+            "nucleotide_change": "c.255T>G",
+            "protein_change": "p.Arg85Arg",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv3197A",
+                    "gene_name": "whiB7",
+                    "feature_id": "CCP46011",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.255T>G",
+                    "protein_change": "p.Arg85Arg",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3197A",
+            "gene_associated_drugs": [
+                "streptomycin",
+                "amikacin",
+                "kanamycin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 3568428,
+            "ref": "T",
+            "alt": "C",
+            "depth": 133,
+            "freq": 0.18796992481203006,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 0,
+            "reverse_reads": 25,
+            "sv_len": null,
+            "gene_id": "Rv3197A",
+            "gene_name": "whiB7",
+            "feature_id": "CCP46011",
+            "type": "synonymous_variant",
+            "change": "c.252A>G",
+            "nucleotide_change": "c.252A>G",
+            "protein_change": "p.Gly84Gly",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv3197A",
+                    "gene_name": "whiB7",
+                    "feature_id": "CCP46011",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.252A>G",
+                    "protein_change": "p.Gly84Gly",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3197A",
+            "gene_associated_drugs": [
+                "streptomycin",
+                "amikacin",
+                "kanamycin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 3568473,
+            "ref": "C",
+            "alt": "A",
+            "depth": 162,
+            "freq": 0.12345679012345678,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 20,
+            "reverse_reads": 0,
+            "sv_len": null,
+            "gene_id": "Rv3197A",
+            "gene_name": "whiB7",
+            "feature_id": "CCP46011",
+            "type": "missense_variant",
+            "change": "p.Glu69Asp",
+            "nucleotide_change": "c.207G>T",
+            "protein_change": "p.Glu69Asp",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv3197A",
+                    "gene_name": "whiB7",
+                    "feature_id": "CCP46011",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.207G>T",
+                    "protein_change": "p.Glu69Asp",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3197A",
+            "gene_associated_drugs": [
+                "streptomycin",
+                "amikacin",
+                "kanamycin"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4038955,
+            "ref": "C",
+            "alt": "A",
+            "depth": 146,
+            "freq": 0.1780821917808219,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 26,
+            "reverse_reads": 0,
+            "sv_len": null,
+            "gene_id": "Rv3596c",
+            "gene_name": "clpC1",
+            "feature_id": "CCP46419",
+            "type": "stop_gained",
+            "change": "p.Glu584*",
+            "nucleotide_change": "c.1750G>T",
+            "protein_change": "p.Glu584*",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv3596c",
+                    "gene_name": "clpC1",
+                    "feature_id": "CCP46419",
+                    "type": "stop_gained",
+                    "nucleotide_change": "c.1750G>T",
+                    "protein_change": "p.Glu584*",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3596c",
+            "gene_associated_drugs": [
+                "pyrazinamide"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4040259,
+            "ref": "T",
+            "alt": "G",
+            "depth": 140,
+            "freq": 0.11428571428571428,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 16,
+            "reverse_reads": 0,
+            "sv_len": null,
+            "gene_id": "Rv3596c",
+            "gene_name": "clpC1",
+            "feature_id": "CCP46419",
+            "type": "missense_variant",
+            "change": "p.Glu149Ala",
+            "nucleotide_change": "c.446A>C",
+            "protein_change": "p.Glu149Ala",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv3596c",
+                    "gene_name": "clpC1",
+                    "feature_id": "CCP46419",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.446A>C",
+                    "protein_change": "p.Glu149Ala",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3596c",
+            "gene_associated_drugs": [
+                "pyrazinamide"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4040950,
+            "ref": "A",
+            "alt": "T",
+            "depth": 34,
+            "freq": 0.20588235294117646,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 0,
+            "reverse_reads": 7,
+            "sv_len": null,
+            "gene_id": "Rv3596c",
+            "gene_name": "clpC1",
+            "feature_id": "CCP46419",
+            "type": "upstream_gene_variant",
+            "change": "c.-246T>A",
+            "nucleotide_change": "c.-246T>A",
+            "protein_change": "",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv3596c",
+                    "gene_name": "clpC1",
+                    "feature_id": "CCP46419",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-246T>A",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3596c",
+            "gene_associated_drugs": [
+                "pyrazinamide"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4040961,
+            "ref": "T",
+            "alt": "G",
+            "depth": 38,
+            "freq": 0.13157894736842105,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 0,
+            "reverse_reads": 5,
+            "sv_len": null,
+            "gene_id": "Rv3596c",
+            "gene_name": "clpC1",
+            "feature_id": "CCP46419",
+            "type": "upstream_gene_variant",
+            "change": "c.-257A>C",
+            "nucleotide_change": "c.-257A>C",
+            "protein_change": "",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv3596c",
+                    "gene_name": "clpC1",
+                    "feature_id": "CCP46419",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-257A>C",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3596c",
+            "gene_associated_drugs": [
+                "pyrazinamide"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4245835,
+            "ref": "T",
+            "alt": "G",
+            "depth": 165,
+            "freq": 0.11515151515151516,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 17,
+            "reverse_reads": 2,
+            "sv_len": null,
+            "gene_id": "Rv3794",
+            "gene_name": "embA",
+            "feature_id": "CCP46623",
+            "type": "missense_variant",
+            "change": "p.Leu868Arg",
+            "nucleotide_change": "c.2603T>G",
+            "protein_change": "p.Leu868Arg",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv3794",
+                    "gene_name": "embA",
+                    "feature_id": "CCP46623",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.2603T>G",
+                    "protein_change": "p.Leu868Arg",
+                    "annotation": []
+                },
+                {
+                    "gene_id": "Rv3795",
+                    "gene_name": "embB",
+                    "feature_id": "CCP46624",
+                    "type": "upstream_gene_variant",
+                    "nucleotide_change": "c.-679T>G",
+                    "protein_change": "",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3794",
+            "gene_associated_drugs": [
+                "ethambutol"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4247055,
+            "ref": "T",
+            "alt": "A",
+            "depth": 129,
+            "freq": 0.13178294573643412,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 17,
+            "reverse_reads": 0,
+            "sv_len": null,
+            "gene_id": "Rv3795",
+            "gene_name": "embB",
+            "feature_id": "CCP46624",
+            "type": "missense_variant",
+            "change": "p.Leu181Gln",
+            "nucleotide_change": "c.542T>A",
+            "protein_change": "p.Leu181Gln",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv3795",
+                    "gene_name": "embB",
+                    "feature_id": "CCP46624",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.542T>A",
+                    "protein_change": "p.Leu181Gln",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3795",
+            "gene_associated_drugs": [
+                "ethambutol"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4248319,
+            "ref": "A",
+            "alt": "T",
+            "depth": 151,
+            "freq": 0.17880794701986755,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 2,
+            "reverse_reads": 25,
+            "sv_len": null,
+            "gene_id": "Rv3795",
+            "gene_name": "embB",
+            "feature_id": "CCP46624",
+            "type": "synonymous_variant",
+            "change": "c.1806A>T",
+            "nucleotide_change": "c.1806A>T",
+            "protein_change": "p.Val602Val",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv3795",
+                    "gene_name": "embB",
+                    "feature_id": "CCP46624",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.1806A>T",
+                    "protein_change": "p.Val602Val",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3795",
+            "gene_associated_drugs": [
+                "ethambutol"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4248324,
+            "ref": "C",
+            "alt": "G",
+            "depth": 170,
+            "freq": 0.18235294117647058,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 0,
+            "reverse_reads": 31,
+            "sv_len": null,
+            "gene_id": "Rv3795",
+            "gene_name": "embB",
+            "feature_id": "CCP46624",
+            "type": "missense_variant",
+            "change": "p.Ala604Gly",
+            "nucleotide_change": "c.1811C>G",
+            "protein_change": "p.Ala604Gly",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv3795",
+                    "gene_name": "embB",
+                    "feature_id": "CCP46624",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.1811C>G",
+                    "protein_change": "p.Ala604Gly",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3795",
+            "gene_associated_drugs": [
+                "ethambutol"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4267416,
+            "ref": "G",
+            "alt": "C",
+            "depth": 197,
+            "freq": 0.12690355329949238,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 25,
+            "reverse_reads": 0,
+            "sv_len": null,
+            "gene_id": "Rv3805c",
+            "gene_name": "aftB",
+            "feature_id": "CCP46634",
+            "type": "missense_variant",
+            "change": "p.Pro474Arg",
+            "nucleotide_change": "c.1421C>G",
+            "protein_change": "p.Pro474Arg",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv3805c",
+                    "gene_name": "aftB",
+                    "feature_id": "CCP46634",
+                    "type": "missense_variant",
+                    "nucleotide_change": "c.1421C>G",
+                    "protein_change": "p.Pro474Arg",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3805c",
+            "gene_associated_drugs": [
+                "ethambutol"
+            ]
+        },
+        {
+            "chrom": "NC_000962.3",
+            "pos": 4338219,
+            "ref": "G",
+            "alt": "T",
+            "depth": 157,
+            "freq": 0.12101910828025478,
+            "sv": false,
+            "filter": "soft_fail",
+            "forward_reads": 18,
+            "reverse_reads": 1,
+            "sv_len": null,
+            "gene_id": "Rv3862c",
+            "gene_name": "whiB6",
+            "feature_id": "CCP46691",
+            "type": "synonymous_variant",
+            "change": "c.303C>A",
+            "nucleotide_change": "c.303C>A",
+            "protein_change": "p.Arg101Arg",
+            "annotation": [],
+            "consequences": [
+                {
+                    "gene_id": "Rv3862c",
+                    "gene_name": "whiB6",
+                    "feature_id": "CCP46691",
+                    "type": "synonymous_variant",
+                    "nucleotide_change": "c.303C>A",
+                    "protein_change": "p.Arg101Arg",
+                    "annotation": []
+                }
+            ],
+            "locus_tag": "Rv3862c",
+            "gene_associated_drugs": [
+                "capreomycin",
+                "amikacin",
+                "kanamycin"
+            ]
         }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Ala187Val",
-      "locus_tag": "Rv0486",
-      "gene": "mshA",
-      "gene_associated_drugs": ["ethionamide", "isoniazid"]
+    ],
+    "qc": {
+        "percent_reads_mapped": 98.25,
+        "num_reads_mapped": 5997058,
+        "target_median_depth": 195.0,
+        "genome_median_depth": 189,
+        "target_qc": [
+            {
+                "target": "dnaA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 185.5
+            },
+            {
+                "target": "gyrB",
+                "percent_depth_pass": 100.0,
+                "median_depth": 217.0
+            },
+            {
+                "target": "gyrA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 216.0
+            },
+            {
+                "target": "Rv0010c",
+                "percent_depth_pass": 100.0,
+                "median_depth": 181.0
+            },
+            {
+                "target": "fgd1",
+                "percent_depth_pass": 100.0,
+                "median_depth": 181.0
+            },
+            {
+                "target": "mshA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 194.0
+            },
+            {
+                "target": "ccsA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 188.0
+            },
+            {
+                "target": "Rv0565c",
+                "percent_depth_pass": 100.0,
+                "median_depth": 205.5
+            },
+            {
+                "target": "hadA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 215.0
+            },
+            {
+                "target": "nusG",
+                "percent_depth_pass": 100.0,
+                "median_depth": 161.0
+            },
+            {
+                "target": "rpoB",
+                "percent_depth_pass": 99.87,
+                "median_depth": 225.0
+            },
+            {
+                "target": "rpoC",
+                "percent_depth_pass": 100.0,
+                "median_depth": 223.0
+            },
+            {
+                "target": "mmpL5",
+                "percent_depth_pass": 100.0,
+                "median_depth": 191.0
+            },
+            {
+                "target": "mmpS5",
+                "percent_depth_pass": 100.0,
+                "median_depth": 205.0
+            },
+            {
+                "target": "mmpR5",
+                "percent_depth_pass": 100.0,
+                "median_depth": 182.0
+            },
+            {
+                "target": "rpsL",
+                "percent_depth_pass": 100.0,
+                "median_depth": 248.0
+            },
+            {
+                "target": "rplC",
+                "percent_depth_pass": 100.0,
+                "median_depth": 241.0
+            },
+            {
+                "target": "Rv1129c",
+                "percent_depth_pass": 100.0,
+                "median_depth": 197.0
+            },
+            {
+                "target": "fbiC",
+                "percent_depth_pass": 100.0,
+                "median_depth": 234.0
+            },
+            {
+                "target": "sigE",
+                "percent_depth_pass": 100.0,
+                "median_depth": 199.0
+            },
+            {
+                "target": "Rv1258c",
+                "percent_depth_pass": 100.0,
+                "median_depth": 167.0
+            },
+            {
+                "target": "embR",
+                "percent_depth_pass": 100.0,
+                "median_depth": 198.0
+            },
+            {
+                "target": "atpE",
+                "percent_depth_pass": 100.0,
+                "median_depth": 165.0
+            },
+            {
+                "target": "rrs",
+                "percent_depth_pass": 100.0,
+                "median_depth": 220.0
+            },
+            {
+                "target": "rrl",
+                "percent_depth_pass": 100.0,
+                "median_depth": 178.0
+            },
+            {
+                "target": "inhA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 183.0
+            },
+            {
+                "target": "rpsA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 238.0
+            },
+            {
+                "target": "tsnR",
+                "percent_depth_pass": 100.0,
+                "median_depth": 180.0
+            },
+            {
+                "target": "tlyA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 214.0
+            },
+            {
+                "target": "cycA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 143.0
+            },
+            {
+                "target": "bacA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 198.0
+            },
+            {
+                "target": "ndh",
+                "percent_depth_pass": 100.0,
+                "median_depth": 195.0
+            },
+            {
+                "target": "katG",
+                "percent_depth_pass": 100.0,
+                "median_depth": 204.0
+            },
+            {
+                "target": "PPE35",
+                "percent_depth_pass": 100.0,
+                "median_depth": 134.0
+            },
+            {
+                "target": "Rv1979c",
+                "percent_depth_pass": 100.0,
+                "median_depth": 227.0
+            },
+            {
+                "target": "pncA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 195.0
+            },
+            {
+                "target": "kasA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 190.0
+            },
+            {
+                "target": "eis",
+                "percent_depth_pass": 100.0,
+                "median_depth": 227.0
+            },
+            {
+                "target": "ahpC",
+                "percent_depth_pass": 100.0,
+                "median_depth": 240.0
+            },
+            {
+                "target": "folC",
+                "percent_depth_pass": 100.0,
+                "median_depth": 183.0
+            },
+            {
+                "target": "Rv2477c",
+                "percent_depth_pass": 100.0,
+                "median_depth": 210.0
+            },
+            {
+                "target": "pepQ",
+                "percent_depth_pass": 100.0,
+                "median_depth": 169.0
+            },
+            {
+                "target": "ribD",
+                "percent_depth_pass": 100.0,
+                "median_depth": 218.0
+            },
+            {
+                "target": "Rv2680",
+                "percent_depth_pass": 100.0,
+                "median_depth": 229.5
+            },
+            {
+                "target": "Rv2681",
+                "percent_depth_pass": 100.0,
+                "median_depth": 187.0
+            },
+            {
+                "target": "Rv2752c",
+                "percent_depth_pass": 100.0,
+                "median_depth": 210.0
+            },
+            {
+                "target": "thyX",
+                "percent_depth_pass": 100.0,
+                "median_depth": 186.0
+            },
+            {
+                "target": "thyA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 190.0
+            },
+            {
+                "target": "ald",
+                "percent_depth_pass": 100.0,
+                "median_depth": 195.0
+            },
+            {
+                "target": "fbiD",
+                "percent_depth_pass": 100.0,
+                "median_depth": 176.0
+            },
+            {
+                "target": "Rv3083",
+                "percent_depth_pass": 100.0,
+                "median_depth": 184.0
+            },
+            {
+                "target": "whiB7",
+                "percent_depth_pass": 100.0,
+                "median_depth": 183.5
+            },
+            {
+                "target": "Rv3236c",
+                "percent_depth_pass": 100.0,
+                "median_depth": 166.0
+            },
+            {
+                "target": "lpqB",
+                "percent_depth_pass": 100.0,
+                "median_depth": 176.0
+            },
+            {
+                "target": "mtrB",
+                "percent_depth_pass": 100.0,
+                "median_depth": 209.0
+            },
+            {
+                "target": "mtrA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 191.0
+            },
+            {
+                "target": "fbiA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 195.0
+            },
+            {
+                "target": "fbiB",
+                "percent_depth_pass": 100.0,
+                "median_depth": 199.0
+            },
+            {
+                "target": "alr",
+                "percent_depth_pass": 100.0,
+                "median_depth": 242.0
+            },
+            {
+                "target": "rpoA",
+                "percent_depth_pass": 96.62,
+                "median_depth": 191.0
+            },
+            {
+                "target": "ddn",
+                "percent_depth_pass": 100.0,
+                "median_depth": 214.0
+            },
+            {
+                "target": "clpC1",
+                "percent_depth_pass": 100.0,
+                "median_depth": 200.0
+            },
+            {
+                "target": "panD",
+                "percent_depth_pass": 100.0,
+                "median_depth": 183.0
+            },
+            {
+                "target": "glpK",
+                "percent_depth_pass": 100.0,
+                "median_depth": 182.0
+            },
+            {
+                "target": "embC",
+                "percent_depth_pass": 100.0,
+                "median_depth": 189.0
+            },
+            {
+                "target": "embA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 180.0
+            },
+            {
+                "target": "embB",
+                "percent_depth_pass": 100.0,
+                "median_depth": 201.0
+            },
+            {
+                "target": "aftB",
+                "percent_depth_pass": 100.0,
+                "median_depth": 172.0
+            },
+            {
+                "target": "ubiA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 185.0
+            },
+            {
+                "target": "ethA",
+                "percent_depth_pass": 100.0,
+                "median_depth": 211.0
+            },
+            {
+                "target": "ethR",
+                "percent_depth_pass": 100.0,
+                "median_depth": 202.0
+            },
+            {
+                "target": "whiB6",
+                "percent_depth_pass": 99.87,
+                "median_depth": 193.0
+            },
+            {
+                "target": "gid",
+                "percent_depth_pass": 100.0,
+                "median_depth": 222.0
+            }
+        ],
+        "missing_positions": [
+            {
+                "chrom": "NC_000962.3",
+                "pos": 761106,
+                "depth": 5,
+                "annotation": [
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434_Asn437delinsIle",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434_Asn437delinsIle"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434_Asp435del",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434_Asp435del"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434_Asp435insVal",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434_Asp435insVal"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434Arg",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434Arg"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434Ile",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434Ile"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434Leu",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434Leu"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434Thr",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434Thr"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434Val",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434Val"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1299_1301delCAT",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1299_1301delCAT"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1296_1307delATTCATGGACCA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1296_1307delATTCATGGACCA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1297_1305delTTCATGGAC",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1297_1305delTTCATGGAC"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1291_1302delAGCCAATTCATG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1291_1302delAGCCAATTCATG"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1293_1304delCCAATTCATGGAinsGAGCCAATTCATGGG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1293_1304delCCAATTCATGGAinsGAGCCAATTCATGGG"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1300_1305delATGGAC",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1300_1305delATGGAC"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1296_1315delATTCATGGACCAGAACAACCinsGAACAACG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1296_1315delATTCATGGACCAGAACAACCinsGAACAACG"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1296_1304delATTCATGGA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1296_1304delATTCATGGA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1284_1300delCCAGCTGAGCCAATTCAinsACAGCTGAGCCAATTCATGG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1284_1300delCCAGCTGAGCCAATTCAinsACAGCTGAGCCAATTCATGG"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1294_1302delCAATTCATG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1294_1302delCAATTCATG"
+                    }
+                ]
+            },
+            {
+                "chrom": "NC_000962.3",
+                "pos": 761107,
+                "depth": 2,
+                "annotation": [
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434_Asn437delinsIle",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434_Asn437delinsIle"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434_Asp435del",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434_Asp435del"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434_Asp435insVal",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434_Asp435insVal"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434Arg",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434Arg"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434Ile",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434Ile"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434Leu",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434Leu"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434Thr",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434Thr"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434Val",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434Val"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1299_1301delCAT",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1299_1301delCAT"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1296_1307delATTCATGGACCA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1296_1307delATTCATGGACCA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1301_1312delTGGACCAGAACA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1301_1312delTGGACCAGAACA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1297_1305delTTCATGGAC",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1297_1305delTTCATGGAC"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1291_1302delAGCCAATTCATG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1291_1302delAGCCAATTCATG"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1293_1304delCCAATTCATGGAinsGAGCCAATTCATGGG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1293_1304delCCAATTCATGGAinsGAGCCAATTCATGGG"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1300_1305delATGGAC",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1300_1305delATGGAC"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1296_1315delATTCATGGACCAGAACAACCinsGAACAACG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1296_1315delATTCATGGACCAGAACAACCinsGAACAACG"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1296_1304delATTCATGGA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1296_1304delATTCATGGA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1294_1302delCAATTCATG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1294_1302delCAATTCATG"
+                    }
+                ]
+            },
+            {
+                "chrom": "NC_000962.3",
+                "pos": 761108,
+                "depth": 2,
+                "annotation": [
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434_Asn437delinsIle",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434_Asn437delinsIle"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434_Asp435del",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434_Asp435del"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434_Asp435insVal",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434_Asp435insVal"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434Arg",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434Arg"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434Ile",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434Ile"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434Leu",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434Leu"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434Thr",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434Thr"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Met434Val",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Met434Val"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1296_1307delATTCATGGACCA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1296_1307delATTCATGGACCA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1302_1310delGGACCAGAA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1302_1310delGGACCAGAA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1301_1312delTGGACCAGAACA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1301_1312delTGGACCAGAACA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1297_1305delTTCATGGAC",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1297_1305delTTCATGGAC"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1291_1302delAGCCAATTCATG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1291_1302delAGCCAATTCATG"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1293_1304delCCAATTCATGGAinsGAGCCAATTCATGGG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1293_1304delCCAATTCATGGAinsGAGCCAATTCATGGG"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1300_1305delATGGAC",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1300_1305delATGGAC"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1296_1315delATTCATGGACCAGAACAACCinsGAACAACG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1296_1315delATTCATGGACCAGAACAACCinsGAACAACG"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1296_1304delATTCATGGA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1296_1304delATTCATGGA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1294_1302delCAATTCATG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1294_1302delCAATTCATG"
+                    }
+                ]
+            },
+            {
+                "chrom": "NC_000962.3",
+                "pos": 761109,
+                "depth": 2,
+                "annotation": [
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435_Gln436del",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435_Gln436del"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435_Gln436delinsGlu",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435_Gln436delinsGlu"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Ala",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Ala"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Asn",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Asn"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Asn",
+                        "confidence": "Uncertain significance",
+                        "source": "fohm",
+                        "comment": "Miotto et al. 2017",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Asn"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435del",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435del"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Glu",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Glu"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Gly",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Gly"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435His",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435His"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Leu",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Leu"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Phe",
+                        "confidence": "Assoc w R",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Phe"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Tyr",
+                        "confidence": "Assoc w R",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Tyr"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Val",
+                        "confidence": "Assoc w R",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Val"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1303_1305delGAC",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1303_1305delGAC"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1296_1307delATTCATGGACCA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1296_1307delATTCATGGACCA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1302_1310delGGACCAGAA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1302_1310delGGACCAGAA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1301_1312delTGGACCAGAACA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1301_1312delTGGACCAGAACA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1297_1305delTTCATGGAC",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1297_1305delTTCATGGAC"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1293_1304delCCAATTCATGGAinsGAGCCAATTCATGGG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1293_1304delCCAATTCATGGAinsGAGCCAATTCATGGG"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1300_1305delATGGAC",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1300_1305delATGGAC"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1303_1317delGACCAGAACAACCCG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1303_1317delGACCAGAACAACCCG"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1296_1315delATTCATGGACCAGAACAACCinsGAACAACG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1296_1315delATTCATGGACCAGAACAACCinsGAACAACG"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1296_1304delATTCATGGA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1296_1304delATTCATGGA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1303_1308delGACCAG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1303_1308delGACCAG"
+                    }
+                ]
+            },
+            {
+                "chrom": "NC_000962.3",
+                "pos": 761110,
+                "depth": 7,
+                "annotation": [
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435_Gln436del",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435_Gln436del"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435_Gln436delinsGlu",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435_Gln436delinsGlu"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Ala",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Ala"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Asn",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Asn"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Asn",
+                        "confidence": "Uncertain significance",
+                        "source": "fohm",
+                        "comment": "Miotto et al. 2017",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Asn"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435del",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435del"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Glu",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Glu"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Gly",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Gly"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435His",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435His"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Leu",
+                        "confidence": "Assoc w R - Interim",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Leu"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Phe",
+                        "confidence": "Assoc w R",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Phe"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Tyr",
+                        "confidence": "Assoc w R",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Tyr"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "p.Asp435Val",
+                        "confidence": "Assoc w R",
+                        "source": "WHO catalogue v2",
+                        "comment": "",
+                        "gene": "Rv0667",
+                        "variant": "p.Asp435Val"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1303_1305delGAC",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1303_1305delGAC"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1296_1307delATTCATGGACCA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1296_1307delATTCATGGACCA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1302_1310delGGACCAGAA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1302_1310delGGACCAGAA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1301_1312delTGGACCAGAACA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1301_1312delTGGACCAGAACA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1297_1305delTTCATGGAC",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1297_1305delTTCATGGAC"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1293_1304delCCAATTCATGGAinsGAGCCAATTCATGGG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1293_1304delCCAATTCATGGAinsGAGCCAATTCATGGG"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1300_1305delATGGAC",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1300_1305delATGGAC"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1304_1336delACCAGAACAACCCGCTGTCGGGGTTGACCCACAinsCCCAGAACAACCCGCTGTCCGGGCCCC",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1304_1336delACCAGAACAACCCGCTGTCGGGGTTGACCCACAinsCCCAGAACAACCCGCTGTCCGGGCCCC"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1303_1317delGACCAGAACAACCCG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1303_1317delGACCAGAACAACCCG"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1296_1315delATTCATGGACCAGAACAACCinsGAACAACG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1296_1315delATTCATGGACCAGAACAACCinsGAACAACG"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1296_1304delATTCATGGA",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1296_1304delATTCATGGA"
+                    },
+                    {
+                        "type": "drug_resistance",
+                        "drug": "rifampicin",
+                        "original_mutation": "c.1303_1308delGACCAG",
+                        "confidence": "",
+                        "source": "tbdb",
+                        "comment": "Mutation from literature",
+                        "gene": "Rv0667",
+                        "variant": "c.1303_1308delGACCAG"
+                    }
+                ]
+            }
+        ]
     },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 576626,
-      "ref": "A",
-      "alt": "C",
-      "depth": 79,
-      "freq": 0.11392405063291139,
-      "feature_id": "CCP43220",
-      "type": "missense_variant",
-      "nucleotide_change": "c.1279A>C",
-      "protein_change": "p.Thr427Pro",
-      "alternate_consequences": [],
-      "change": "p.Thr427Pro",
-      "locus_tag": "Rv0486",
-      "gene": "mshA",
-      "gene_associated_drugs": ["ethionamide", "isoniazid"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 576631,
-      "ref": "C",
-      "alt": "A",
-      "depth": 83,
-      "freq": 0.13253012048192772,
-      "feature_id": "CCP43220",
-      "type": "missense_variant",
-      "nucleotide_change": "c.1284C>A",
-      "protein_change": "p.Phe428Leu",
-      "alternate_consequences": [],
-      "change": "p.Phe428Leu",
-      "locus_tag": "Rv0486",
-      "gene": "mshA",
-      "gene_associated_drugs": ["ethionamide", "isoniazid"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 620625,
-      "ref": "A",
-      "alt": "G",
-      "depth": 186,
-      "freq": 1.0,
-      "feature_id": "CCP43266",
-      "type": "missense_variant",
-      "nucleotide_change": "c.735A>G",
-      "protein_change": "p.Ile245Met",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "amikacin",
-          "who_confidence": "Not assoc w R"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "capreomycin",
-          "who_confidence": "Not assoc w R"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Ile245Met",
-      "locus_tag": "Rv0529",
-      "gene": "ccsA",
-      "gene_associated_drugs": ["capreomycin", "amikacin"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 763031,
-      "ref": "T",
-      "alt": "C",
-      "depth": 215,
-      "freq": 1.0,
-      "feature_id": "CCP43411",
-      "type": "upstream_gene_variant",
-      "nucleotide_change": "c.-339T>C",
-      "protein_change": "",
-      "alternate_consequences": [
-        {
-          "gene_name": "rpoB",
-          "gene_id": "Rv0667",
-          "feature_id": "CCP43410",
-          "type": "synonymous_variant",
-          "nucleotide_change": "c.3225T>C",
-          "protein_change": "p.Ala1075Ala"
-        }
-      ],
-      "change": "c.-339T>C",
-      "locus_tag": "Rv0668",
-      "gene": "rpoC",
-      "gene_associated_drugs": ["rifampicin"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 775639,
-      "ref": "T",
-      "alt": "C",
-      "depth": 207,
-      "freq": 1.0,
-      "feature_id": "CCP43419",
-      "type": "missense_variant",
-      "nucleotide_change": "c.2842A>G",
-      "protein_change": "p.Ile948Val",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "bedaquiline",
-          "who_confidence": "Not assoc w R"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "clofazimine",
-          "who_confidence": "Not assoc w R"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Ile948Val",
-      "locus_tag": "Rv0676c",
-      "gene": "mmpL5",
-      "gene_associated_drugs": ["clofazimine", "bedaquiline"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 776100,
-      "ref": "G",
-      "alt": "A",
-      "depth": 198,
-      "freq": 1.0,
-      "feature_id": "CCP43419",
-      "type": "missense_variant",
-      "nucleotide_change": "c.2381C>T",
-      "protein_change": "p.Thr794Ile",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "clofazimine",
-          "who_confidence": "Not assoc w R"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "bedaquiline",
-          "who_confidence": "Not assoc w R"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Thr794Ile",
-      "locus_tag": "Rv0676c",
-      "gene": "mmpL5",
-      "gene_associated_drugs": ["clofazimine", "bedaquiline"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 776182,
-      "ref": "C",
-      "alt": "T",
-      "depth": 157,
-      "freq": 1.0,
-      "feature_id": "CCP43419",
-      "type": "missense_variant",
-      "nucleotide_change": "c.2299G>A",
-      "protein_change": "p.Asp767Asn",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "clofazimine",
-          "who_confidence": "Not assoc w R"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "bedaquiline",
-          "who_confidence": "Not assoc w R"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Asp767Asn",
-      "locus_tag": "Rv0676c",
-      "gene": "mmpL5",
-      "gene_associated_drugs": ["clofazimine", "bedaquiline"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 779615,
-      "ref": "G",
-      "alt": "C",
-      "depth": 195,
-      "freq": 1.0,
-      "feature_id": "CCP43420",
-      "type": "upstream_gene_variant",
-      "nucleotide_change": "c.-710C>G",
-      "protein_change": "",
-      "alternate_consequences": [],
-      "change": "c.-710C>G",
-      "locus_tag": "Rv0677c",
-      "gene": "mmpS5",
-      "gene_associated_drugs": ["clofazimine", "bedaquiline"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 781395,
-      "ref": "T",
-      "alt": "C",
-      "depth": 224,
-      "freq": 1.0,
-      "feature_id": "CCP43425",
-      "type": "upstream_gene_variant",
-      "nucleotide_change": "c.-165T>C",
-      "protein_change": "",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "streptomycin",
-          "who_confidence": "Not assoc w R"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "c.-165T>C",
-      "locus_tag": "Rv0682",
-      "gene": "rpsL",
-      "gene_associated_drugs": ["streptomycin"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 1406760,
-      "ref": "T",
-      "alt": "TG",
-      "depth": 193,
-      "freq": 1.0,
-      "feature_id": "CCP44014",
-      "type": "frameshift_variant",
-      "nucleotide_change": "c.580_581insC",
-      "protein_change": "p.Glu194fs",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "isoniazid",
-          "who_confidence": "Uncertain significance"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "isoniazid",
-          "who_confidence": "Not assoc w R"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "streptomycin",
-          "who_confidence": "Uncertain significance"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "pyrazinamide",
-          "who_confidence": "Uncertain significance"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "pyrazinamide",
-          "who_confidence": "Not assoc w R"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "streptomycin",
-          "who_confidence": "Not assoc w R"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "c.580_581insC",
-      "locus_tag": "Rv1258c",
-      "gene": "Rv1258c",
-      "gene_associated_drugs": ["streptomycin", "pyrazinamide", "isoniazid"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 1471659,
-      "ref": "C",
-      "alt": "T",
-      "depth": 142,
-      "freq": 1.0,
-      "feature_id": "EBG00000313325-1",
-      "type": "upstream_gene_variant",
-      "nucleotide_change": "n.-187C>T",
-      "protein_change": "",
-      "alternate_consequences": [],
-      "change": "n.-187C>T",
-      "locus_tag": "EBG00000313325",
-      "gene": "rrs",
-      "gene_associated_drugs": [
-        "linezolid",
-        "kanamycin",
-        "capreomycin",
-        "amikacin",
-        "aminoglycosides",
-        "streptomycin"
-      ]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 1834177,
-      "ref": "A",
-      "alt": "C",
-      "depth": 246,
-      "freq": 0.991869918699187,
-      "feature_id": "CCP44394",
-      "type": "synonymous_variant",
-      "nucleotide_change": "c.636A>C",
-      "protein_change": "p.Arg212Arg",
-      "alternate_consequences": [],
-      "change": "c.636A>C",
-      "locus_tag": "Rv1630",
-      "gene": "rpsA",
-      "gene_associated_drugs": ["pyrazinamide"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 1917972,
-      "ref": "A",
-      "alt": "G",
-      "depth": 166,
-      "freq": 1.0,
-      "feature_id": "CCP44459",
-      "type": "synonymous_variant",
-      "nucleotide_change": "c.33A>G",
-      "protein_change": "p.Leu11Leu",
-      "alternate_consequences": [],
-      "change": "c.33A>G",
-      "locus_tag": "Rv1694",
-      "gene": "tlyA",
-      "gene_associated_drugs": ["capreomycin"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 2154724,
-      "ref": "C",
-      "alt": "A",
-      "depth": 212,
-      "freq": 1.0,
-      "feature_id": "CCP44675",
-      "type": "missense_variant",
-      "nucleotide_change": "c.1388G>T",
-      "protein_change": "p.Arg463Leu",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "isoniazid",
-          "who_confidence": "Not assoc w R"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Arg463Leu",
-      "locus_tag": "Rv1908c",
-      "gene": "katG",
-      "gene_associated_drugs": ["isoniazid"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 2167926,
-      "ref": "A",
-      "alt": "G",
-      "depth": 142,
-      "freq": 1.0,
-      "feature_id": "CCP44685",
-      "type": "missense_variant",
-      "nucleotide_change": "c.2687T>C",
-      "protein_change": "p.Leu896Ser",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "pyrazinamide",
-          "who_confidence": "Not assoc w R"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Leu896Ser",
-      "locus_tag": "Rv1918c",
-      "gene": "PPE35",
-      "gene_associated_drugs": ["pyrazinamide"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 2170086,
-      "ref": "G",
-      "alt": "C",
-      "depth": 44,
-      "freq": 0.11363636363636363,
-      "feature_id": "CCP44685",
-      "type": "missense_variant",
-      "nucleotide_change": "c.527C>G",
-      "protein_change": "p.Ala176Gly",
-      "alternate_consequences": [],
-      "change": "p.Ala176Gly",
-      "locus_tag": "Rv1918c",
-      "gene": "PPE35",
-      "gene_associated_drugs": ["pyrazinamide"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 2223293,
-      "ref": "T",
-      "alt": "C",
-      "depth": 163,
-      "freq": 1.0,
-      "feature_id": "CCP44748",
-      "type": "upstream_gene_variant",
-      "nucleotide_change": "c.-129A>G",
-      "protein_change": "",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "bedaquiline",
-          "who_confidence": "Not assoc w R"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "clofazimine",
-          "who_confidence": "Not assoc w R"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "c.-129A>G",
-      "locus_tag": "Rv1979c",
-      "gene": "Rv1979c",
-      "gene_associated_drugs": ["clofazimine", "bedaquiline"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 2714526,
-      "ref": "GGT",
-      "alt": "G",
-      "depth": 196,
-      "freq": 1.0,
-      "feature_id": "CCP45207",
-      "type": "frameshift_variant",
-      "nucleotide_change": "c.805_806delAC",
-      "protein_change": "p.Thr269fs",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "amikacin",
-          "who_confidence": "Uncertain significance"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "amikacin",
-          "who_confidence": "Not assoc w R"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "kanamycin",
-          "who_confidence": "Uncertain significance"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "amikacin",
-          "who_confidence": "Uncertain significance"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "c.805_806delAC",
-      "locus_tag": "Rv2416c",
-      "gene": "eis",
-      "gene_associated_drugs": ["kanamycin", "amikacin"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 3086788,
-      "ref": "T",
-      "alt": "C",
-      "depth": 168,
-      "freq": 1.0,
-      "feature_id": "CCP45579",
-      "type": "upstream_gene_variant",
-      "nucleotide_change": "c.-32T>C",
-      "protein_change": "",
-      "alternate_consequences": [],
-      "change": "c.-32T>C",
-      "locus_tag": "Rv2780",
-      "gene": "ald",
-      "gene_associated_drugs": ["cycloserine"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 3339726,
-      "ref": "A",
-      "alt": "T",
-      "depth": 56,
-      "freq": 0.16071428571428573,
-      "feature_id": "CCP45788",
-      "type": "synonymous_variant",
-      "nucleotide_change": "c.609A>T",
-      "protein_change": "p.Val203Val",
-      "alternate_consequences": [],
-      "change": "c.609A>T",
-      "locus_tag": "Rv2983",
-      "gene": "fbiD",
-      "gene_associated_drugs": ["delamanid"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 3339744,
-      "ref": "A",
-      "alt": "T",
-      "depth": 31,
-      "freq": 0.12903225806451613,
-      "feature_id": "CCP45788",
-      "type": "synonymous_variant",
-      "nucleotide_change": "c.627A>T",
-      "protein_change": "p.Arg209Arg",
-      "alternate_consequences": [],
-      "change": "c.627A>T",
-      "locus_tag": "Rv2983",
-      "gene": "fbiD",
-      "gene_associated_drugs": ["delamanid"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 3339750,
-      "ref": "C",
-      "alt": "G",
-      "depth": 38,
-      "freq": 0.15789473684210525,
-      "feature_id": "CCP45788",
-      "type": "synonymous_variant",
-      "nucleotide_change": "c.633C>G",
-      "protein_change": "p.Val211Val",
-      "alternate_consequences": [],
-      "change": "c.633C>G",
-      "locus_tag": "Rv2983",
-      "gene": "fbiD",
-      "gene_associated_drugs": ["delamanid"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 3473996,
-      "ref": "G",
-      "alt": "GA",
-      "depth": 154,
-      "freq": 1.0,
-      "feature_id": "CCP45916",
-      "type": "upstream_gene_variant",
-      "nucleotide_change": "c.-11_-10insA",
-      "protein_change": "",
-      "alternate_consequences": [],
-      "change": "c.-11_-10insA",
-      "locus_tag": "Rv3106",
-      "gene": "fprA",
-      "gene_associated_drugs": ["capreomycin", "amikacin"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 3568428,
-      "ref": "T",
-      "alt": "C",
-      "depth": 87,
-      "freq": 0.1839080459770115,
-      "feature_id": "CCP46011",
-      "type": "synonymous_variant",
-      "nucleotide_change": "c.252A>G",
-      "protein_change": "p.Gly84Gly",
-      "alternate_consequences": [],
-      "change": "c.252A>G",
-      "locus_tag": "Rv3197A",
-      "gene": "whiB7",
-      "gene_associated_drugs": ["streptomycin", "kanamycin", "amikacin"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 3568473,
-      "ref": "C",
-      "alt": "A",
-      "depth": 103,
-      "freq": 0.14563106796116504,
-      "feature_id": "CCP46011",
-      "type": "missense_variant",
-      "nucleotide_change": "c.207G>T",
-      "protein_change": "p.Glu69Asp",
-      "alternate_consequences": [],
-      "change": "p.Glu69Asp",
-      "locus_tag": "Rv3197A",
-      "gene": "whiB7",
-      "gene_associated_drugs": ["streptomycin", "kanamycin", "amikacin"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 3612813,
-      "ref": "T",
-      "alt": "C",
-      "depth": 118,
-      "freq": 1.0,
-      "feature_id": "CCP46055",
-      "type": "missense_variant",
-      "nucleotide_change": "c.304A>G",
-      "protein_change": "p.Thr102Ala",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "pyrazinamide",
-          "who_confidence": "Not assoc w R"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Thr102Ala",
-      "locus_tag": "Rv3236c",
-      "gene": "Rv3236c",
-      "gene_associated_drugs": ["pyrazinamide"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 4038955,
-      "ref": "C",
-      "alt": "A",
-      "depth": 131,
-      "freq": 0.1450381679389313,
-      "feature_id": "CCP46419",
-      "type": "stop_gained",
-      "nucleotide_change": "c.1750G>T",
-      "protein_change": "p.Glu584*",
-      "alternate_consequences": [],
-      "change": "p.Glu584*",
-      "locus_tag": "Rv3596c",
-      "gene": "clpC1",
-      "gene_associated_drugs": ["pyrazinamide"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 4242643,
-      "ref": "C",
-      "alt": "T",
-      "depth": 158,
-      "freq": 1.0,
-      "feature_id": "CCP46623",
-      "type": "upstream_gene_variant",
-      "nucleotide_change": "c.-590C>T",
-      "protein_change": "",
-      "alternate_consequences": [
-        {
-          "gene_name": "embC",
-          "gene_id": "Rv3793",
-          "feature_id": "CCP46622",
-          "type": "synonymous_variant",
-          "nucleotide_change": "c.2781C>T",
-          "protein_change": "p.Arg927Arg"
-        }
-      ],
-      "change": "c.-590C>T",
-      "locus_tag": "Rv3794",
-      "gene": "embA",
-      "gene_associated_drugs": ["ethambutol"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 4243460,
-      "ref": "C",
-      "alt": "T",
-      "depth": 177,
-      "freq": 1.0,
-      "feature_id": "CCP46623",
-      "type": "synonymous_variant",
-      "nucleotide_change": "c.228C>T",
-      "protein_change": "p.Cys76Cys",
-      "alternate_consequences": [],
-      "change": "c.228C>T",
-      "locus_tag": "Rv3794",
-      "gene": "embA",
-      "gene_associated_drugs": ["ethambutol"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 4247015,
-      "ref": "T",
-      "alt": "G",
-      "depth": 94,
-      "freq": 0.1702127659574468,
-      "feature_id": "CCP46624",
-      "type": "missense_variant",
-      "nucleotide_change": "c.502T>G",
-      "protein_change": "p.Ser168Ala",
-      "alternate_consequences": [],
-      "change": "p.Ser168Ala",
-      "locus_tag": "Rv3795",
-      "gene": "embB",
-      "gene_associated_drugs": ["ethambutol"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 4247028,
-      "ref": "T",
-      "alt": "G",
-      "depth": 86,
-      "freq": 0.16279069767441862,
-      "feature_id": "CCP46624",
-      "type": "missense_variant",
-      "nucleotide_change": "c.515T>G",
-      "protein_change": "p.Leu172Arg",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "ethambutol",
-          "who_confidence": "Uncertain significance"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Leu172Arg",
-      "locus_tag": "Rv3795",
-      "gene": "embB",
-      "gene_associated_drugs": ["ethambutol"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 4267647,
-      "ref": "T",
-      "alt": "C",
-      "depth": 125,
-      "freq": 1.0,
-      "feature_id": "CCP46634",
-      "type": "missense_variant",
-      "nucleotide_change": "c.1190A>G",
-      "protein_change": "p.Asp397Gly",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "capreomycin",
-          "who_confidence": "Not assoc w R"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "amikacin",
-          "who_confidence": "Not assoc w R"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Asp397Gly",
-      "locus_tag": "Rv3805c",
-      "gene": "aftB",
-      "gene_associated_drugs": ["capreomycin", "amikacin"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 4338219,
-      "ref": "G",
-      "alt": "T",
-      "depth": 137,
-      "freq": 0.11678832116788321,
-      "feature_id": "CCP46691",
-      "type": "synonymous_variant",
-      "nucleotide_change": "c.303C>A",
-      "protein_change": "p.Arg101Arg",
-      "alternate_consequences": [],
-      "change": "c.303C>A",
-      "locus_tag": "Rv3862c",
-      "gene": "whiB6",
-      "gene_associated_drugs": ["streptomycin", "capreomycin", "amikacin"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 4338595,
-      "ref": "GC",
-      "alt": "G",
-      "depth": 224,
-      "freq": 0.9955357142857143,
-      "feature_id": "CCP46691",
-      "type": "upstream_gene_variant",
-      "nucleotide_change": "c.-75delG",
-      "protein_change": "",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "streptomycin",
-          "who_confidence": "Not assoc w R"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "capreomycin",
-          "who_confidence": "Uncertain significance"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "streptomycin",
-          "who_confidence": "Uncertain significance"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "capreomycin",
-          "who_confidence": "Not assoc w R"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "amikacin",
-          "who_confidence": "Not assoc w R"
-        },
-        {
-          "type": "who_confidence",
-          "drug": "amikacin",
-          "who_confidence": "Uncertain significance"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "c.-75delG",
-      "locus_tag": "Rv3862c",
-      "gene": "whiB6",
-      "gene_associated_drugs": ["streptomycin", "capreomycin", "amikacin"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 4407588,
-      "ref": "T",
-      "alt": "C",
-      "depth": 233,
-      "freq": 1.0,
-      "feature_id": "CCP46748",
-      "type": "synonymous_variant",
-      "nucleotide_change": "c.615A>G",
-      "protein_change": "p.Ala205Ala",
-      "alternate_consequences": [],
-      "change": "c.615A>G",
-      "locus_tag": "Rv3919c",
-      "gene": "gid",
-      "gene_associated_drugs": ["streptomycin"]
-    },
-    {
-      "chrom": "Chromosome",
-      "genome_pos": 4407927,
-      "ref": "T",
-      "alt": "G",
-      "depth": 247,
-      "freq": 0.9959514170040485,
-      "feature_id": "CCP46748",
-      "type": "missense_variant",
-      "nucleotide_change": "c.276A>C",
-      "protein_change": "p.Glu92Asp",
-      "annotation": [
-        {
-          "type": "who_confidence",
-          "drug": "streptomycin",
-          "who_confidence": "Not assoc w R"
-        }
-      ],
-      "alternate_consequences": [],
-      "change": "p.Glu92Asp",
-      "locus_tag": "Rv3919c",
-      "gene": "gid",
-      "gene_associated_drugs": ["streptomycin"]
-    }
-  ],
-  "drtype": "MDR-TB",
-  "db_version": {
-    "name": "tbdb",
-    "commit": "c2fb9a2",
-    "Author": "jodyphelan <jody.phelan@lshtm.ac.uk>",
-    "Date": "Tue Oct 4 11:40:15 2022 +0100"
-  },
-  "pipeline": [
-    { "Analysis": "Mapping", "Program": "mtuberculosis_test_1_1.fastq.gz" },
-    { "Analysis": "Variant calling", "Program": "freebayes" }
-  ],
-  "timestamp": "23-12-2023 21:42:24"
+    "linked_samples": []
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -137,9 +137,7 @@ def test_cdm_input_cmd(
     runner = CliRunner()
     with runner.isolated_filesystem():
         output_fname = "test_ouptut"
-        result = runner.invoke(
-            create_cdm_input,
-            [
+        args = [
                 "--quast",
                 ecoli_quast_path,
                 "--quality",
@@ -148,16 +146,16 @@ def test_cdm_input_cmd(
                 ecoli_chewbbaca_path,
                 "--output",
                 output_fname,
-            ],
-        )
+            ]
+        result = runner.invoke(create_cdm_input, args)
 
         # test successful execution of command
         assert result.exit_code == 0
 
         # test correct output format
         with open(output_fname, "rb") as inpt:
-            cmd_output = json.load(inpt)
-            assert cmd_output == ecoli_cdm_input
+            cdm_output = json.load(inpt)
+            assert cdm_output == ecoli_cdm_input
 
 
 def test_annotate_delly(


### PR DESCRIPTION
### Added

 - Added `rerun_bonsai_input` to rerun bonsai-prp outputs when output format changes
 - Added `symlink_dir` as possible filepaths prefix for IGV inputs
 - Added kraken cutoff whereby species prediction needs to have >= 0.01% of read hits
 - Added phylogenetic statistics to result for tb
 - Added source of variant to output

### Fixed

 - Handling of tbprofiler v6.2.0 results

### Changed

 - Changed all click types to click.Path()
 - Removed `ref_accession != bam_ref_genome` check