### PR TITLE
Add support for species prediction from multiple softwares to PRP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ### Added
 
+ - Added species prediction and phylo group from Mykrobe.
+
 ### Fixed
 
 ### Changed
+
+ - Changed `species_prediction` field to be a key-value indexed array to support multiple SPP predictions.
 
 ## [0.8.0]
 

--- a/prp/cli.py
+++ b/prp/cli.py
@@ -37,6 +37,7 @@ from .parse import (
     parse_virulencefinder_stx_typing,
     parse_virulencefinder_vir_pred,
 )
+from .parse.species import get_mykrobe_spp_prediction
 from .parse.metadata import get_database_info, get_gb_genome_version, parse_run_info
 from .parse.utils import _get_path, get_db_version, parse_input_dir
 from .parse.variant import annotate_delly_variants
@@ -229,11 +230,10 @@ def create_bonsai_input(
             results["typing_result"].extend(res)
 
     # species id
+    results["species_prediction"] = []
     if kraken:
         LOG.info("Parse kraken results")
-        results["species_prediction"] = parse_kraken_result(kraken)
-    else:
-        results["species_prediction"] = []
+        results["species_prediction"].append(parse_kraken_result(kraken))
 
     # mycobacterium tuberculosis
     # mykrobe
@@ -271,6 +271,9 @@ def create_bonsai_input(
         )
         if lin_res is not None:
             results["typing_result"].append(lin_res)
+
+        # parse mykrobe species prediction result
+        results["species_prediction"].append(get_mykrobe_spp_prediction(pred_res))
 
     # tbprofiler
     if tbprofiler:

--- a/prp/models/sample.py
+++ b/prp/models/sample.py
@@ -7,7 +7,7 @@ from .base import RWModel
 from .metadata import RunMetadata
 from .phenotype import ElementType, ElementTypeResult, PredictionSoftware, VariantBase
 from .qc import QcMethodIndex
-from .species import SpeciesPredictionResult
+from .species import SppMethodIndex
 from .typing import (
     TypingMethod,
     TypingResultCgMlst,
@@ -37,7 +37,7 @@ class SampleBase(RWModel):
 
     run_metadata: RunMetadata = Field(..., alias="runMetadata")
     qc: List[QcMethodIndex] = Field(...)
-    species_prediction: SpeciesPredictionResult = Field(..., alias="speciesPrediction")
+    species_prediction: List[SppMethodIndex] = Field(..., alias="speciesPrediction")
 
 
 class ReferenceGenome(RWModel):

--- a/prp/models/species.py
+++ b/prp/models/species.py
@@ -1,8 +1,10 @@
 """Species related data models."""
+
 from enum import Enum
 from typing import List
 
 from pydantic import Field
+from .phenotype import ElementTypeResult, PredictionSoftware
 
 from .base import RWModel
 
@@ -18,15 +20,44 @@ class TaxLevel(Enum):
     S = "species"
 
 
+class SppPredictionSoftware(Enum):
+    """Container for prediciton software names."""
+
+    MYKROBE = "mykrobe"
+    TBPROFILER = "tbprofiler"
+    BRACKEN = "bracken"
+
+
 class SpeciesPrediction(RWModel):
     """Species prediction results."""
 
     scientific_name: str = Field(..., alias="scientificName")
-    taxonomy_id: int = Field(..., alias="taxId")
+    taxonomy_id: int | None = Field(..., alias="taxId")
+
+
+class BrackenSpeciesPrediction(SpeciesPrediction):
+    """Species prediction results."""
+
     taxonomy_lvl: TaxLevel = Field(..., alias="taxLevel")
     kraken_assigned_reads: int = Field(..., alias="krakenAssignedReads")
     added_reads: int = Field(..., alias="addedReads")
     fraction_total_reads: float = Field(..., alias="fractionTotalReads")
 
 
-SpeciesPredictionResult = List[SpeciesPrediction]
+class MykrobeSpeciesPrediction(SpeciesPrediction):
+    """Mykrobe species prediction results."""
+
+    phylogenetic_group: str = Field(
+        ..., description="Group with phylogenetic related species."
+    )
+    phylogenetic_group_coverage: float = Field(
+        ..., description="Kmer converage for phylo group."
+    )
+    species_coverage: float = Field(..., description="Species kmer converage.")
+
+
+class SppMethodIndex(RWModel):
+    """Container for key-value lookup of analytical results."""
+
+    software: SppPredictionSoftware
+    result: List[BrackenSpeciesPrediction | MykrobeSpeciesPrediction]

--- a/prp/parse/species.py
+++ b/prp/parse/species.py
@@ -1,12 +1,15 @@
 """Parsers for species prediction tools."""
+
 import logging
+from typing import Dict, Any, List
 
 import pandas as pd
+from prp.models.species import SppMethodIndex, SppPredictionSoftware, MykrobeSpeciesPrediction
 
 LOG = logging.getLogger(__name__)
 
 
-def parse_kraken_result(file: str, cutoff: float = 0.0001):
+def parse_kraken_result(file: str, cutoff: float = 0.0001) -> SppMethodIndex:
     """parse_species_pred""Parse species prediciton result"""
     tax_lvl_dict = {
         "P": "phylum",
@@ -24,4 +27,23 @@ def parse_kraken_result(file: str, cutoff: float = 0.0001):
         .replace({"taxonomy_lvl": tax_lvl_dict})
         .loc[lambda df: df["fraction_total_reads"] >= cutoff]
     )
-    return species_pred.to_dict(orient="records")
+    # cast as method index
+    return SppMethodIndex(
+        software=SppPredictionSoftware.BRACKEN,
+        result=species_pred.to_dict(orient="records"),
+    )
+
+def get_mykrobe_spp_prediction(prediction: List[Dict[str, Any]]) -> SppMethodIndex:
+    """Get species prediction result from Mykrobe."""
+    LOG.info("Parsing Mykrobe spp result.")
+    spp_pred = MykrobeSpeciesPrediction(
+        scientific_name=prediction[0]["species"].replace("_", " "),
+        taxonomy_id=None,
+        phylogenetic_group=prediction[0]["phylo_group"].replace("_", " "),
+        phylogenetic_group_coverage=prediction[0]["phylo_group_per_covg"],
+        species_coverage=prediction[0]["species_per_covg"],
+    )
+    return SppMethodIndex(
+        software=SppPredictionSoftware.MYKROBE,
+        result=[spp_pred]
+    )


### PR DESCRIPTION
This PR changes the output format to add support for multiple species prediction softwares.

It also adds species prediction and phylogroup prediction from Mykrobe.

Close #62 