### PR TITLE
Fixed compatibility issues with lineage parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Fixed
 
+- Updated lineage parser to work with TbProfiler v6.2
+
 ### Changed
+
+- Changes lineage datamodel to reflect changes in TbProfiler output
 
 ## [0.8.1]
 

--- a/prp/cli.py
+++ b/prp/cli.py
@@ -37,8 +37,8 @@ from .parse import (
     parse_virulencefinder_stx_typing,
     parse_virulencefinder_vir_pred,
 )
-from .parse.species import get_mykrobe_spp_prediction
 from .parse.metadata import get_database_info, get_gb_genome_version, parse_run_info
+from .parse.species import get_mykrobe_spp_prediction
 from .parse.utils import _get_path, get_db_version, parse_input_dir
 from .parse.variant import annotate_delly_variants
 
@@ -262,13 +262,11 @@ def create_bonsai_input(
             )
         )
         # parse mykrobe result
-        amr_res = parse_mykrobe_amr_pred(pred_res, ElementType.AMR)
+        amr_res = parse_mykrobe_amr_pred(pred_res)
         if amr_res is not None:
             results["element_type_result"].append(amr_res)
 
-        lin_res: MethodIndex | None = parse_mykrobe_lineage_results(
-            pred_res, TypingMethod.LINEAGE
-        )
+        lin_res: MethodIndex | None = parse_mykrobe_lineage_results(pred_res)
         if lin_res is not None:
             results["typing_result"].append(lin_res)
 
@@ -289,11 +287,9 @@ def create_bonsai_input(
                 )
             ]
             results["run_metadata"]["databases"].extend(db_info)
-            lin_res: MethodIndex = parse_tbprofiler_lineage_results(
-                pred_res, TypingMethod.LINEAGE
-            )
+            lin_res: MethodIndex = parse_tbprofiler_lineage_results(pred_res)
             results["typing_result"].append(lin_res)
-            amr_res: MethodIndex = parse_tbprofiler_amr_pred(pred_res, ElementType.AMR)
+            amr_res: MethodIndex = parse_tbprofiler_amr_pred(pred_res)
             results["element_type_result"].append(amr_res)
 
     # parse SNV and SV variants.

--- a/prp/models/sample.py
+++ b/prp/models/sample.py
@@ -9,10 +9,11 @@ from .phenotype import ElementType, ElementTypeResult, PredictionSoftware, Varia
 from .qc import QcMethodIndex
 from .species import SppMethodIndex
 from .typing import (
+    ResultLineageBase,
+    TbProfilerLineage,
     TypingMethod,
     TypingResultCgMlst,
     TypingResultGeneAllele,
-    TypingResultLineage,
     TypingResultMlst,
     TypingSoftware,
 )
@@ -27,8 +28,9 @@ class MethodIndex(RWModel):
         ElementTypeResult,
         TypingResultMlst,
         TypingResultCgMlst,
-        TypingResultLineage,
         TypingResultGeneAllele,
+        TbProfilerLineage,
+        ResultLineageBase,
     ]
 
 

--- a/prp/models/species.py
+++ b/prp/models/species.py
@@ -4,9 +4,9 @@ from enum import Enum
 from typing import List
 
 from pydantic import Field
-from .phenotype import ElementTypeResult, PredictionSoftware
 
 from .base import RWModel
+from .phenotype import ElementTypeResult, PredictionSoftware
 
 
 class TaxLevel(Enum):

--- a/prp/models/typing.py
+++ b/prp/models/typing.py
@@ -51,28 +51,10 @@ class MlstErrors(str, Enum):
     PARTIAL = "partial"
 
 
-class LineageInformation(RWModel):
-    """Base class for storing lineage information typing results"""
-
-    lin: str | None = None
-    family: str | None = None
-    spoligotype: str | None = None
-    rd: str | None = None
-    fraction: float | None = None
-    variant: str | None = None
-    coverage: Dict[str, Any] | None = None
-
-
 class ResultMlstBase(RWModel):
     """Base class for storing MLST-like typing results"""
 
     alleles: Dict[str, Union[int, str, List, None]]
-
-
-class ResultLineageBase(RWModel):
-    """Base class for storing MLST-like typing results"""
-
-    lineages: List[LineageInformation]
 
 
 class TypingResultMlst(ResultMlstBase):
@@ -89,21 +71,28 @@ class TypingResultCgMlst(ResultMlstBase):
     n_missing: int = Field(0, alias="nNovel")
 
 
-class TypingResultLineage(ResultLineageBase):
+class ResultLineageBase(RWModel):
     """Lineage results"""
 
     lineage_depth: float | None = None
-    main_lin: str
-    sublin: str
+    main_lineage: str
+    sublineage: str
 
 
-class TypingResultPhylogenetics(TypingResultLineage):
-    """Phylogenetics results"""
+class LineageInformation(RWModel):
+    """Base class for storing lineage information typing results"""
 
-    phylo_group_depth: float | None = None
-    phylo_group: str | None = None
-    species_depth: float | None = None
-    species: str | None = None
+    lineage: str | None
+    family: str | None
+    rd: str | None
+    fraction: float | None
+    support: List[Dict[str, Any]] | None = None
+
+
+class TbProfilerLineage(ResultLineageBase):
+    """Base class for storing MLST-like typing results"""
+
+    lineages: List[LineageInformation]
 
 
 class TypingResultGeneAllele(VirulenceGene, SerotypeGene):

--- a/prp/parse/phenotype/mykrobe.py
+++ b/prp/parse/phenotype/mykrobe.py
@@ -142,9 +142,7 @@ def _parse_mykrobe_amr_variants(mykrobe_result) -> Tuple[MykrobeVariant, ...]:
     return variants
 
 
-def parse_mykrobe_amr_pred(
-    prediction: Dict[str, Any], resistance_category
-) -> ElementTypeResult | None:
+def parse_mykrobe_amr_pred(prediction: Dict[str, Any]) -> ElementTypeResult | None:
     """Parse mykrobe resistance prediction results."""
     LOG.info("Parsing mykrobe prediction")
     resistance = ElementTypeResult(
@@ -158,6 +156,6 @@ def parse_mykrobe_amr_pred(
         result = None
     else:
         result = MethodIndex(
-            type=resistance_category, software=Software.MYKROBE, result=resistance
+            type=ElementType.AMR, software=Software.MYKROBE, result=resistance
         )
     return result

--- a/prp/parse/phenotype/tbprofiler.py
+++ b/prp/parse/phenotype/tbprofiler.py
@@ -129,11 +129,12 @@ def parse_drug_resistance_info(drugs: List[Dict[str, str]]) -> List[PhenotypeInf
             drug_type = ElementType.AMR
         else:
             drug_type = ElementType.AMR
-            LOG.warning((
-                "Unknown TbProfiler drug; drug: %s"
-                ", confers resistance with confidence"
-                ": %s; default to %s"
-            ),
+            LOG.warning(
+                (
+                    "Unknown TbProfiler drug; drug: %s"
+                    ", confers resistance with confidence"
+                    ": %s; default to %s"
+                ),
                 drug["type"],
                 drug["confidence"],
                 drug_type,
@@ -154,7 +155,7 @@ def parse_drug_resistance_info(drugs: List[Dict[str, str]]) -> List[PhenotypeInf
 
 
 def parse_tbprofiler_amr_pred(
-    prediction: Dict[str, Any], resistance_category
+    prediction: Dict[str, Any]
 ) -> Tuple[SoupVersions, ElementTypeResult]:
     """Parse tbprofiler resistance prediction results."""
     LOG.info("Parsing tbprofiler prediction")
@@ -164,5 +165,5 @@ def parse_tbprofiler_amr_pred(
         variants=_parse_tbprofiler_amr_variants(prediction),
     )
     return MethodIndex(
-        type=resistance_category, software=Software.TBPROFILER, result=resistance
+        type=ElementType.AMR, software=Software.TBPROFILER, result=resistance
     )

--- a/prp/parse/species.py
+++ b/prp/parse/species.py
@@ -1,10 +1,15 @@
 """Parsers for species prediction tools."""
 
 import logging
-from typing import Dict, Any, List
+from typing import Any, Dict, List
 
 import pandas as pd
-from prp.models.species import SppMethodIndex, SppPredictionSoftware, MykrobeSpeciesPrediction
+
+from prp.models.species import (
+    MykrobeSpeciesPrediction,
+    SppMethodIndex,
+    SppPredictionSoftware,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -33,6 +38,7 @@ def parse_kraken_result(file: str, cutoff: float = 0.0001) -> SppMethodIndex:
         result=species_pred.to_dict(orient="records"),
     )
 
+
 def get_mykrobe_spp_prediction(prediction: List[Dict[str, Any]]) -> SppMethodIndex:
     """Get species prediction result from Mykrobe."""
     LOG.info("Parsing Mykrobe spp result.")
@@ -43,7 +49,4 @@ def get_mykrobe_spp_prediction(prediction: List[Dict[str, Any]]) -> SppMethodInd
         phylogenetic_group_coverage=prediction[0]["phylo_group_per_covg"],
         species_coverage=prediction[0]["species_per_covg"],
     )
-    return SppMethodIndex(
-        software=SppPredictionSoftware.MYKROBE,
-        result=[spp_pred]
-    )
+    return SppMethodIndex(software=SppPredictionSoftware.MYKROBE, result=[spp_pred])


### PR DESCRIPTION
This PR updates the TbProfiler lineage parser to work with the updated TbProfiler output format. It also updates the naming of fields in the datamodel to be more consistent with naming in other data models.