### PR TITLE
Use literals to ensure that data is being cast into right datamodel

### DIFF
--- a/prp/cli.py
+++ b/prp/cli.py
@@ -1,8 +1,8 @@
 """Definition of the PRP command-line interface."""
+
 import json
 import logging
 from pathlib import Path
-from typing import List
 
 import click
 import numpy as np
@@ -287,7 +287,7 @@ def create_bonsai_input(
         LOG.info("Parse tbprofiler results")
         with open(tbprofiler, "r", encoding="utf-8") as tbprofiler_json:
             pred_res = json.load(tbprofiler_json)
-            db_info: List[SoupVersion] = []
+            db_info: list[SoupVersion] = []
             db_info = [
                 SoupVersion(
                     name=pred_res["pipeline"]["db_version"]["name"],
@@ -436,7 +436,7 @@ def create_cdm_input(quast, quality, cgmlst, correct_alleles, output) -> None:
         )
         results.append(n_missing_loci)
     # cast output as pydantic type for easy serialization
-    qc_data = TypeAdapter(List[QcMethodIndex])
+    qc_data = TypeAdapter(list[QcMethodIndex])
 
     LOG.info("Storing results to: %s", output.name)
     output.write(qc_data.dump_json(results, indent=3).decode("utf-8"))

--- a/prp/models/metadata.py
+++ b/prp/models/metadata.py
@@ -1,7 +1,6 @@
 """Metadata models."""
 from datetime import datetime
 from enum import Enum
-from typing import List
 
 from pydantic import BaseModel, Field
 
@@ -34,7 +33,7 @@ class RunInformation(RWModel):
         alias="analysisProfile",
         description="The analysis profile used when starting the pipeline",
     )
-    configuration_files: List[str] = Field(
+    configuration_files: list[str] = Field(
         ..., alias="configurationFiles", description="Nextflow configuration used"
     )
     workflow_name: str
@@ -47,7 +46,7 @@ class RunInformation(RWModel):
     date: datetime
 
 
-SoupVersions = List[SoupVersion]
+SoupVersions = list[SoupVersion]
 
 
 class RunMetadata(BaseModel):

--- a/prp/models/phenotype.py
+++ b/prp/models/phenotype.py
@@ -1,20 +1,20 @@
 """Datamodels used for prediction results."""
 from enum import Enum
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Literal
 
 from pydantic import BaseModel, Field
 
 from .base import RWModel
 
 
-class SequenceStand(Enum):
+class SequenceStand(str, Enum):
     """Definition of DNA strand."""
 
     FORWARD = "+"
     REVERSE = "-"
 
 
-class PredictionSoftware(Enum):
+class PredictionSoftware(str, Enum):
     """Container for prediciton software names."""
 
     AMRFINDER = "amrfinder"
@@ -25,7 +25,7 @@ class PredictionSoftware(Enum):
     TBPROFILER = "tbprofiler"
 
 
-class VariantType(Enum):
+class VariantType(str, Enum):
     """Types of variants."""
 
     SNV = "SNV"
@@ -34,7 +34,7 @@ class VariantType(Enum):
     STR = "STR"
 
 
-class VariantSubType(Enum):
+class VariantSubType(str, Enum):
     """Variant subtypes."""
 
     INSERTION = "INS"
@@ -47,7 +47,7 @@ class VariantSubType(Enum):
     TRANSLOCATION = "BND"
 
 
-class ElementType(Enum):
+class ElementType(str, Enum):
     """Categories of resistance and virulence genes."""
 
     AMR = "AMR"
@@ -56,7 +56,7 @@ class ElementType(Enum):
     ANTIGEN = "ANTIGEN"
 
 
-class ElementStressSubtype(Enum):
+class ElementStressSubtype(str, Enum):
     """Categories of resistance and virulence genes."""
 
     ACID = "ACID"
@@ -65,14 +65,14 @@ class ElementStressSubtype(Enum):
     HEAT = "HEAT"
 
 
-class ElementAmrSubtype(Enum):
+class ElementAmrSubtype(str, Enum):
     """Categories of resistance genes."""
 
     AMR = "AMR"
     POINT = "POINT"
 
 
-class ElementVirulenceSubtype(Enum):
+class ElementVirulenceSubtype(str, Enum):
     """Categories of resistance and virulence genes."""
 
     VIR = "VIRULENCE"
@@ -80,14 +80,14 @@ class ElementVirulenceSubtype(Enum):
     TOXIN = "TOXIN"
 
 
-class AnnotationType(Enum):
+class AnnotationType(str, Enum):
     """Valid annotation types."""
 
     TOOL = "tool"
     USER = "user"
 
 
-class ElementSerotypeSubtype(Enum):
+class ElementSerotypeSubtype(str, Enum):
     """Categories of serotype genes."""
 
     ANTIGEN = "ANTIGEN"
@@ -167,6 +167,10 @@ class AmrFinderGene(GeneBase):
     )
     query_end_pos: int = Field(default=None, description="End position on the assembly")
     strand: SequenceStand
+
+
+class AmrFinderVirulenceGene(AmrFinderGene):
+    """Container for a virulence gene for AMRfinder."""
 
 
 class AmrFinderResistanceGene(AmrFinderGene):
@@ -254,6 +258,18 @@ class TbProfilerVariant(VariantBase):
     )
 
 
+class VirulenceElementTypeResult(BaseModel):
+    """Phenotype result data model.
+
+    A phenotype result is a generic data structure that stores predicted genes,
+    mutations and phenotyp changes.
+    """
+
+    phenotypes: Dict[str, List[str]]
+    genes: List[AmrFinderVirulenceGene | VirulenceGene]
+    variants: List
+
+
 class ElementTypeResult(BaseModel):
     """Phenotype result data model.
 
@@ -263,6 +279,38 @@ class ElementTypeResult(BaseModel):
 
     phenotypes: Dict[str, List[str]]
     genes: List[
-        Union[AmrFinderResistanceGene, AmrFinderGene, ResfinderGene, VirulenceGene]
+        Union[AmrFinderResistanceGene, AmrFinderGene, ResfinderGene]
     ]
     variants: List[Union[TbProfilerVariant, MykrobeVariant, ResfinderVariant]]
+
+
+class AMRMethodIndex(RWModel):
+    """Container for key-value lookup of analytical results."""
+
+    type: Literal[ElementType.AMR]
+    software: PredictionSoftware
+    result: ElementTypeResult
+
+
+class AntigenMethodIndex(RWModel):
+    """Container for key-value lookup of analytical results."""
+
+    type: Literal[ElementType.ANTIGEN]
+    software: PredictionSoftware
+    result: ElementTypeResult
+
+
+class StressMethodIndex(RWModel):
+    """Container for key-value lookup of analytical results."""
+
+    type: Literal[ElementType.STRESS]
+    software: PredictionSoftware
+    result: ElementTypeResult
+
+
+class VirulenceMethodIndex(RWModel):
+    """Container for key-value lookup of analytical results."""
+
+    type: Literal[ElementType.VIR]
+    software: PredictionSoftware
+    result: VirulenceElementTypeResult

--- a/prp/models/phenotype.py
+++ b/prp/models/phenotype.py
@@ -1,6 +1,6 @@
 """Datamodels used for prediction results."""
 from enum import Enum
-from typing import Dict, List, Optional, Union, Literal
+from typing import Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -107,7 +107,7 @@ class PhenotypeInfo(RWModel):
     annotation_type: AnnotationType = Field(..., description="Annotation type")
     annotation_author: str | None = Field(None, description="Annotation author")
     # what information substansiate the annotation
-    reference: List[str] = Field([], description="References supporting trait")
+    reference: list[str] = Field([], description="References supporting trait")
     note: str | None = Field(None, description="Note, can be used for confidence score")
     source: str | None = Field(None, description="Source of variant")
 
@@ -176,13 +176,13 @@ class AmrFinderVirulenceGene(AmrFinderGene):
 class AmrFinderResistanceGene(AmrFinderGene):
     """AMRfinder resistance gene information."""
 
-    phenotypes: List[PhenotypeInfo] = []
+    phenotypes: list[PhenotypeInfo] = []
 
 
 class ResistanceGene(GeneBase):
     """Container for resistance gene information"""
 
-    phenotypes: List[PhenotypeInfo] = []
+    phenotypes: list[PhenotypeInfo] = []
 
 
 class SerotypeGene(GeneBase):
@@ -212,7 +212,7 @@ class VariantBase(RWModel):
     id: int
     variant_type: VariantType
     variant_subtype: VariantSubType
-    phenotypes: List[PhenotypeInfo] = []
+    phenotypes: list[PhenotypeInfo] = []
 
     # variant location
     reference_sequence: str = Field(
@@ -265,9 +265,9 @@ class VirulenceElementTypeResult(BaseModel):
     mutations and phenotyp changes.
     """
 
-    phenotypes: Dict[str, List[str]]
-    genes: List[AmrFinderVirulenceGene | VirulenceGene]
-    variants: List
+    phenotypes: dict[str, list[str]]
+    genes: list[AmrFinderVirulenceGene | VirulenceGene]
+    variants: list
 
 
 class ElementTypeResult(BaseModel):
@@ -277,11 +277,9 @@ class ElementTypeResult(BaseModel):
     mutations and phenotyp changes.
     """
 
-    phenotypes: Dict[str, List[str]]
-    genes: List[
-        Union[AmrFinderResistanceGene, AmrFinderGene, ResfinderGene]
-    ]
-    variants: List[Union[TbProfilerVariant, MykrobeVariant, ResfinderVariant]]
+    phenotypes: dict[str, list[str]]
+    genes: list[Union[AmrFinderResistanceGene, AmrFinderGene, ResfinderGene]]
+    variants: list[Union[TbProfilerVariant, MykrobeVariant, ResfinderVariant]]
 
 
 class AMRMethodIndex(RWModel):

--- a/prp/models/qc.py
+++ b/prp/models/qc.py
@@ -1,6 +1,5 @@
 """QC data models."""
 from enum import Enum
-from typing import Dict
 
 from pydantic import BaseModel, Field
 
@@ -36,7 +35,7 @@ class PostAlignQcResult(BaseModel):
     ins_size: int | None = None
     ins_size_dev: int | None = None
     mean_cov: int
-    pct_above_x: Dict[str, float]
+    pct_above_x: dict[str, float]
     n_reads: int
     n_mapped_reads: int
     n_read_pairs: int

--- a/prp/models/sample.py
+++ b/prp/models/sample.py
@@ -1,31 +1,28 @@
 """Data model definition of input/ output data"""
 
-from typing import Dict, List, Optional, Union, Literal
+from typing import Literal, Optional, Union
 
 from pydantic import Field
 
 from .base import RWModel
 from .metadata import RunMetadata
 from .phenotype import (
-    ElementType,
-    ElementTypeResult,
-    PredictionSoftware,
-    VariantBase,
-    VirulenceMethodIndex,
     AMRMethodIndex,
     StressMethodIndex,
+    VariantBase,
+    VirulenceMethodIndex,
 )
 from .qc import QcMethodIndex
 from .species import SppMethodIndex
 from .typing import (
     ResultLineageBase,
+    ShigaTypingMethodIndex,
     TbProfilerLineage,
     TypingMethod,
     TypingResultCgMlst,
     TypingResultGeneAllele,
     TypingResultMlst,
     TypingSoftware,
-    ShigaTypingMethodIndex,
 )
 
 
@@ -47,8 +44,8 @@ class SampleBase(RWModel):
     """Base datamodel for sample data structure"""
 
     run_metadata: RunMetadata = Field(..., alias="runMetadata")
-    qc: List[QcMethodIndex] = Field(...)
-    species_prediction: List[SppMethodIndex] = Field(..., alias="speciesPrediction")
+    qc: list[QcMethodIndex] = Field(...)
+    species_prediction: list[SppMethodIndex] = Field(..., alias="speciesPrediction")
 
 
 class ReferenceGenome(RWModel):
@@ -74,9 +71,9 @@ class PipelineResult(SampleBase):
         Union[VirulenceMethodIndex, AMRMethodIndex, StressMethodIndex, MethodIndex]
     ] = Field(..., alias="elementTypeResult")
     # optional variant info
-    snv_variants: Optional[List[VariantBase]] = None
-    sv_variants: Optional[List[VariantBase]] = None
+    snv_variants: Optional[list[VariantBase]] = None
+    sv_variants: Optional[list[VariantBase]] = None
     # optional alignment info
     reference_genome: Optional[ReferenceGenome] = None
     read_mapping: Optional[str] = None
-    genome_annotation: Optional[List[Dict[str, str]]] = None
+    genome_annotation: Optional[list[dict[str, str]]] = None

--- a/prp/models/sample.py
+++ b/prp/models/sample.py
@@ -1,11 +1,20 @@
 """Data model definition of input/ output data"""
-from typing import Dict, List, Optional, Union
+
+from typing import Dict, List, Optional, Union, Literal
 
 from pydantic import Field
 
 from .base import RWModel
 from .metadata import RunMetadata
-from .phenotype import ElementType, ElementTypeResult, PredictionSoftware, VariantBase
+from .phenotype import (
+    ElementType,
+    ElementTypeResult,
+    PredictionSoftware,
+    VariantBase,
+    VirulenceMethodIndex,
+    AMRMethodIndex,
+    StressMethodIndex,
+)
 from .qc import QcMethodIndex
 from .species import SppMethodIndex
 from .typing import (
@@ -15,22 +24,20 @@ from .typing import (
     TypingResultCgMlst,
     TypingResultGeneAllele,
     TypingResultMlst,
-    TypingResultShiga,
     TypingSoftware,
+    ShigaTypingMethodIndex,
 )
 
 
 class MethodIndex(RWModel):
     """Container for key-value lookup of analytical results."""
 
-    type: Union[ElementType, TypingMethod]
-    software: PredictionSoftware | TypingSoftware | None
+    type: TypingMethod
+    software: TypingSoftware | None
     result: Union[
-        ElementTypeResult,
         TypingResultMlst,
         TypingResultCgMlst,
         TypingResultGeneAllele,
-        TypingResultShiga,
         TbProfilerLineage,
         ResultLineageBase,
     ]
@@ -57,11 +64,15 @@ class ReferenceGenome(RWModel):
 class PipelineResult(SampleBase):
     """Input format of sample object from pipeline."""
 
-    schema_version: int = Field(..., alias="schemaVersion", gt=0)
+    schema_version: Literal[1] = 1
     # optional typing
-    typing_result: List[MethodIndex] = Field(..., alias="typingResult")
+    typing_result: list[Union[ShigaTypingMethodIndex, MethodIndex]] = Field(
+        ..., alias="typingResult"
+    )
     # optional phenotype prediction
-    element_type_result: List[MethodIndex] = Field(..., alias="elementTypeResult")
+    element_type_result: list[
+        Union[VirulenceMethodIndex, AMRMethodIndex, StressMethodIndex, MethodIndex]
+    ] = Field(..., alias="elementTypeResult")
     # optional variant info
     snv_variants: Optional[List[VariantBase]] = None
     sv_variants: Optional[List[VariantBase]] = None

--- a/prp/models/species.py
+++ b/prp/models/species.py
@@ -1,12 +1,10 @@
 """Species related data models."""
 
 from enum import Enum
-from typing import List
 
 from pydantic import Field
 
 from .base import RWModel
-from .phenotype import ElementTypeResult, PredictionSoftware
 
 
 class TaxLevel(Enum):
@@ -60,4 +58,4 @@ class SppMethodIndex(RWModel):
     """Container for key-value lookup of analytical results."""
 
     software: SppPredictionSoftware
-    result: List[BrackenSpeciesPrediction | MykrobeSpeciesPrediction]
+    result: list[BrackenSpeciesPrediction | MykrobeSpeciesPrediction]

--- a/prp/models/tags.py
+++ b/prp/models/tags.py
@@ -1,7 +1,6 @@
 """Definition of tags."""
 
 from enum import Enum
-from typing import List
 
 from .base import RWModel
 
@@ -50,4 +49,4 @@ class Tag(RWModel):
     severity: TagSeverity
 
 
-TagList = List[Tag]
+TagList = list[Tag]

--- a/prp/models/typing.py
+++ b/prp/models/typing.py
@@ -1,7 +1,7 @@
 """Typing related data models"""
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union, Literal
+from typing import Any, Literal, Optional, Union
 
 from pydantic import Field
 
@@ -56,7 +56,7 @@ class MlstErrors(str, Enum):
 class ResultMlstBase(RWModel):
     """Base class for storing MLST-like typing results"""
 
-    alleles: Dict[str, Union[int, str, List, None]]
+    alleles: dict[str, Union[int, str, list, None]]
 
 
 class TypingResultMlst(ResultMlstBase):
@@ -110,17 +110,17 @@ class LineageInformation(RWModel):
     family: str | None
     rd: str | None
     fraction: float | None
-    support: List[Dict[str, Any]] | None = None
+    support: list[dict[str, Any]] | None = None
 
 
 class TbProfilerLineage(ResultLineageBase):
     """Base class for storing MLST-like typing results"""
 
-    lineages: List[LineageInformation]
+    lineages: list[LineageInformation]
 
 
 class TypingResultGeneAllele(VirulenceGene, SerotypeGene):
     """Identification of individual gene alleles."""
 
 
-CgmlstAlleles = Dict[str, int | None | ChewbbacaErrors | MlstErrors | List[int]]
+CgmlstAlleles = dict[str, int | None | ChewbbacaErrors | MlstErrors | list[int]]

--- a/prp/models/typing.py
+++ b/prp/models/typing.py
@@ -1,7 +1,7 @@
 """Typing related data models"""
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, Literal
 
 from pydantic import Field
 
@@ -9,7 +9,7 @@ from .base import RWModel
 from .phenotype import SerotypeGene, VirulenceGene
 
 
-class TypingSoftware(Enum):
+class TypingSoftware(str, Enum):
     """Container for software names."""
 
     CHEWBBACA = "chewbbaca"
@@ -21,7 +21,7 @@ class TypingSoftware(Enum):
     SHIGAPASS = "shigapass"
 
 
-class TypingMethod(Enum):
+class TypingMethod(str, Enum):
     """Valid typing methods."""
 
     MLST = "mlst"
@@ -85,6 +85,14 @@ class TypingResultShiga(RWModel):
     predicted_serotype: Optional[str] = None
     predicted_flex_serotype: Optional[str] = None
     comments: Optional[str] = None
+
+
+class ShigaTypingMethodIndex(RWModel):
+    """Method Index Shiga."""
+
+    type: Literal[TypingMethod.SHIGATYPE]
+    software: Literal[TypingSoftware.SHIGAPASS]
+    result: TypingResultShiga
 
 
 class ResultLineageBase(RWModel):

--- a/prp/parse/metadata.py
+++ b/prp/parse/metadata.py
@@ -1,7 +1,6 @@
 """Parse metadata passed to pipeline."""
 import json
 import logging
-from typing import List
 
 from Bio import SeqIO
 
@@ -10,13 +9,13 @@ from ..models.metadata import RunInformation, SoupVersion
 LOG = logging.getLogger(__name__)
 
 
-def get_database_info(process_metadata: List[str]) -> List[SoupVersion]:
+def get_database_info(process_metadata: list[str]) -> list[SoupVersion]:
     """Get database or software information.
 
-    :param process_metadata: List of file objects for db records.
-    :type process_metadata: List[str]
+    :param process_metadata: list of file objects for db records.
+    :type process_metadata: list[str]
     :return: Description of software or database version.
-    :rtype: List[SoupVersion]
+    :rtype: list[SoupVersion]
     """
     db_info = []
     for soup_filepath in process_metadata:

--- a/prp/parse/phenotype/amrfinder.py
+++ b/prp/parse/phenotype/amrfinder.py
@@ -3,17 +3,21 @@ import logging
 from typing import Tuple
 
 import pandas as pd
+import numpy as np
 
 from ...models.phenotype import (
-    AmrFinderGene,
+    AmrFinderVirulenceGene,
     AmrFinderResistanceGene,
     AnnotationType,
     ElementType,
     ElementTypeResult,
     PhenotypeInfo,
+    VirulenceElementTypeResult,
+    AMRMethodIndex,
+    StressMethodIndex,
+    VirulenceMethodIndex,
 )
 from ...models.phenotype import PredictionSoftware as Software
-from ...models.sample import MethodIndex
 
 LOG = logging.getLogger(__name__)
 
@@ -86,12 +90,12 @@ def _parse_amrfinder_amr_results(
     return ElementTypeResult(phenotypes=sr_profile, genes=genes, variants=[])
 
 
-def parse_amrfinder_amr_pred(file: str, element_type: ElementType) -> ElementTypeResult:
+def parse_amrfinder_amr_pred(file: str, element_type: ElementType) -> AMRMethodIndex:
     """Parse amrfinder resistance prediction results."""
     LOG.info("Parsing amrfinder amr prediction")
-    with open(file, "rb") as tsvfile:
-        hits = pd.read_csv(tsvfile, delimiter="\t")
-        hits = hits.rename(
+    hits = (
+        pd.read_csv(file, delimiter="\t")
+        .rename(
             columns={
                 "Contig id": "contig_id",
                 "Gene symbol": "gene_symbol",
@@ -107,21 +111,26 @@ def parse_amrfinder_amr_pred(file: str, element_type: ElementType) -> ElementTyp
                 "Name of closest sequence": "close_seq_name",
             }
         )
-        hits = hits.drop(columns=["Protein identifier", "HMM id", "HMM description"])
-        hits = hits.where(pd.notnull(hits), None)
-        # group predictions based on their element type
-        predictions = hits.loc[
-            lambda row: row.element_type == element_type.value
+        .drop(columns=["Protein identifier", "HMM id", "HMM description"])
+        .replace(np.nan, None)
+    )
+    # group predictions based on their element type
+    predictions = hits.loc[
+        lambda row: row.element_type == element_type.value
         ].to_dict(orient="records")
-        results: ElementTypeResult = _parse_amrfinder_amr_results(predictions)
-    return MethodIndex(type=element_type, result=results, software=Software.AMRFINDER)
+    results: ElementTypeResult = _parse_amrfinder_amr_results(predictions)
+    if element_type == ElementType.AMR:
+        result = AMRMethodIndex(type=element_type, result=results, software=Software.AMRFINDER)
+    else:
+        result = StressMethodIndex(type=element_type, result=results, software=Software.AMRFINDER)
+    return result
 
 
-def _parse_amrfinder_vir_results(predictions: dict) -> ElementTypeResult:
+def _parse_amrfinder_vir_results(predictions: dict) -> VirulenceElementTypeResult:
     """Parse amrfinder prediction results from amrfinderplus."""
     genes = []
     for prediction in predictions:
-        gene = AmrFinderGene(
+        gene = AmrFinderVirulenceGene(
             # info
             gene_symbol=prediction["gene_symbol"],
             accession=prediction["close_seq_accn"],
@@ -144,15 +153,15 @@ def _parse_amrfinder_vir_results(predictions: dict) -> ElementTypeResult:
         genes.append(gene)
     # sort genes
     genes = sorted(genes, key=lambda entry: (entry.gene_symbol, entry.coverage))
-    return ElementTypeResult(phenotypes={}, genes=genes, variants=[])
+    return VirulenceElementTypeResult(phenotypes={}, genes=genes, variants=[])
 
 
-def parse_amrfinder_vir_pred(file: str):
+def parse_amrfinder_vir_pred(file: str) -> VirulenceMethodIndex:
     """Parse amrfinder virulence prediction results."""
     LOG.info("Parsing amrfinder virulence prediction")
-    with open(file, "rb") as tsvfile:
-        hits = pd.read_csv(tsvfile, delimiter="\t")
-        hits = hits.rename(
+    hits = (
+        pd.read_csv(file, delimiter="\t")
+        .rename(
             columns={
                 "Contig id": "contig_id",
                 "Gene symbol": "gene_symbol",
@@ -168,12 +177,13 @@ def parse_amrfinder_vir_pred(file: str):
                 "Name of closest sequence": "close_seq_name",
             }
         )
-        hits = hits.drop(columns=["Protein identifier", "HMM id", "HMM description"])
-        hits = hits.where(pd.notnull(hits), None)
-        predictions = hits[hits["element_type"] == "VIRULENCE"].to_dict(
-            orient="records"
-        )
-        results: ElementTypeResult = _parse_amrfinder_vir_results(predictions)
-    return MethodIndex(
+        .drop(columns=["Protein identifier", "HMM id", "HMM description"])
+        .replace(np.nan, None)
+    )
+    predictions = hits[hits["element_type"] == "VIRULENCE"].to_dict(
+        orient="records"
+    )
+    results: VirulenceElementTypeResult = _parse_amrfinder_vir_results(predictions)
+    return VirulenceMethodIndex(
         type=ElementType.VIR, software=Software.AMRFINDER, result=results
     )

--- a/prp/parse/phenotype/amrfinder.py
+++ b/prp/parse/phenotype/amrfinder.py
@@ -1,30 +1,31 @@
 """Parse AMRfinder plus result."""
 import logging
-from typing import Tuple
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 from ...models.phenotype import (
-    AmrFinderVirulenceGene,
     AmrFinderResistanceGene,
+    AmrFinderVirulenceGene,
+    AMRMethodIndex,
     AnnotationType,
     ElementType,
     ElementTypeResult,
     PhenotypeInfo,
-    VirulenceElementTypeResult,
-    AMRMethodIndex,
-    StressMethodIndex,
-    VirulenceMethodIndex,
 )
 from ...models.phenotype import PredictionSoftware as Software
+from ...models.phenotype import (
+    StressMethodIndex,
+    VirulenceElementTypeResult,
+    VirulenceMethodIndex,
+)
 
 LOG = logging.getLogger(__name__)
 
 
 def _parse_amrfinder_amr_results(
     predictions: dict,
-) -> Tuple[AmrFinderResistanceGene, ...]:
+) -> tuple[AmrFinderResistanceGene, ...]:
     """Parse amrfinder prediction results from amrfinderplus."""
     genes = []
     for prediction in predictions:
@@ -115,14 +116,18 @@ def parse_amrfinder_amr_pred(file: str, element_type: ElementType) -> AMRMethodI
         .replace(np.nan, None)
     )
     # group predictions based on their element type
-    predictions = hits.loc[
-        lambda row: row.element_type == element_type.value
-        ].to_dict(orient="records")
+    predictions = hits.loc[lambda row: row.element_type == element_type.value].to_dict(
+        orient="records"
+    )
     results: ElementTypeResult = _parse_amrfinder_amr_results(predictions)
     if element_type == ElementType.AMR:
-        result = AMRMethodIndex(type=element_type, result=results, software=Software.AMRFINDER)
+        result = AMRMethodIndex(
+            type=element_type, result=results, software=Software.AMRFINDER
+        )
     else:
-        result = StressMethodIndex(type=element_type, result=results, software=Software.AMRFINDER)
+        result = StressMethodIndex(
+            type=element_type, result=results, software=Software.AMRFINDER
+        )
     return result
 
 
@@ -180,9 +185,7 @@ def parse_amrfinder_vir_pred(file: str) -> VirulenceMethodIndex:
         .drop(columns=["Protein identifier", "HMM id", "HMM description"])
         .replace(np.nan, None)
     )
-    predictions = hits[hits["element_type"] == "VIRULENCE"].to_dict(
-        orient="records"
-    )
+    predictions = hits[hits["element_type"] == "VIRULENCE"].to_dict(orient="records")
     results: VirulenceElementTypeResult = _parse_amrfinder_vir_results(predictions)
     return VirulenceMethodIndex(
         type=ElementType.VIR, software=Software.AMRFINDER, result=results

--- a/prp/parse/phenotype/mykrobe.py
+++ b/prp/parse/phenotype/mykrobe.py
@@ -9,6 +9,7 @@ from ...models.phenotype import (
     ElementTypeResult,
     MykrobeVariant,
     PhenotypeInfo,
+    AMRMethodIndex,
 )
 from ...models.phenotype import PredictionSoftware as Software
 from ...models.phenotype import VariantSubType, VariantType
@@ -142,7 +143,7 @@ def _parse_mykrobe_amr_variants(mykrobe_result) -> Tuple[MykrobeVariant, ...]:
     return variants
 
 
-def parse_mykrobe_amr_pred(prediction: Dict[str, Any]) -> ElementTypeResult | None:
+def parse_mykrobe_amr_pred(prediction: Dict[str, Any]) -> AMRMethodIndex | None:
     """Parse mykrobe resistance prediction results."""
     LOG.info("Parsing mykrobe prediction")
     resistance = ElementTypeResult(
@@ -155,7 +156,7 @@ def parse_mykrobe_amr_pred(prediction: Dict[str, Any]) -> ElementTypeResult | No
     if is_prediction_result_empty(resistance):
         result = None
     else:
-        result = MethodIndex(
+        result = AMRMethodIndex(
             type=ElementType.AMR, software=Software.MYKROBE, result=resistance
         )
     return result

--- a/prp/parse/phenotype/mykrobe.py
+++ b/prp/parse/phenotype/mykrobe.py
@@ -1,19 +1,19 @@
 """Parse Mykrobe results."""
+
 import logging
 import re
-from typing import Any, Dict, Tuple
+from typing import Any, Union
 
 from ...models.phenotype import (
+    AMRMethodIndex,
     AnnotationType,
     ElementType,
     ElementTypeResult,
     MykrobeVariant,
     PhenotypeInfo,
-    AMRMethodIndex,
 )
 from ...models.phenotype import PredictionSoftware as Software
 from ...models.phenotype import VariantSubType, VariantType
-from ...models.sample import MethodIndex
 from ..utils import get_nt_change, is_prediction_result_empty
 
 LOG = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ def _get_mykrobe_amr_sr_profie(mykrobe_result):
     return {"susceptible": list(susceptible), "resistant": list(resistant)}
 
 
-def get_mutation_type(var_nom: str) -> Tuple[VariantSubType, str, str, int]:
+def get_mutation_type(var_nom: str) -> tuple[str, Union[VariantSubType, str, int]]:
     """Extract mutation type from Mykrobe mutation description.
 
     GCG7569GTG -> mutation type, ref_nt, alt_nt, pos
@@ -46,7 +46,7 @@ def get_mutation_type(var_nom: str) -> Tuple[VariantSubType, str, str, int]:
     :param var_nom: Mykrobe mutation description
     :type var_nom: str
     :return: Return variant type, ref_codon, alt_codont and position
-    :rtype: Tuple[VariantSubType, str, str, int]
+    :rtype: dict[str, Union[VariantSubType, str, int]]
     """
     mut_type = None
     ref_codon = None
@@ -70,10 +70,16 @@ def get_mutation_type(var_nom: str) -> Tuple[VariantSubType, str, str, int]:
     else:
         var_type = VariantType.SNV
         var_sub_type = VariantSubType.SUBSTITUTION
-    return var_type, var_sub_type, ref_codon, alt_codon, position
+    return {
+        "type": var_type,
+        "subtype": var_sub_type,
+        "ref": ref_codon,
+        "alt": alt_codon,
+        "pos": position,
+    }
 
 
-def _parse_mykrobe_amr_variants(mykrobe_result) -> Tuple[MykrobeVariant, ...]:
+def _parse_mykrobe_amr_variants(mykrobe_result) -> tuple[MykrobeVariant, ...]:
     """Get resistance genes from mykrobe result."""
     results = []
 
@@ -99,40 +105,47 @@ def _parse_mykrobe_amr_variants(mykrobe_result) -> Tuple[MykrobeVariant, ...]:
         # Mykrobe CSV variant format
         # <gene>_<aa change>-<nt change>:<ref depth>:<alt depth>:<gt confidence>
         # ref: https://github.com/Mykrobe-tools/mykrobe/wiki/AMR-prediction-output
-        pattern = re.compile(r"(.+)_(.+)-(.+):(\d+):(\d+):(\d+)", re.I)
+        pattern = re.compile(
+            r"(?P<gene>.+)_(?P<aa_change>.+)-(?P<dna_change>.+)"
+            r":(?P<ref_depth>\d+):(?P<alt_depth>\d+):(?P<conf>\d+)",
+            re.I,
+        )
         for var_id, variant in enumerate(variants, start=1):
             # extract variant info using regex
-            match = re.search(pattern, variant)
-            gene, aa_change, dna_change, ref_depth, alt_depth, conf = match.groups()
+            match_obj = re.search(pattern, variant).groupdict()
 
             # get type of variant
-            var_type, var_sub_type, ref_aa, alt_aa, _ = get_mutation_type(aa_change)
+            var_aa = get_mutation_type(match_obj["aa_change"])
+            # var_type, var_sub_type, ref_aa, alt_aa, _ = get_mutation_type(aa_change)
 
             # reduce codon to nt change for substitutions
-            _, _, ref_nt, alt_nt, position = get_mutation_type(dna_change)
-            if var_sub_type == VariantSubType.SUBSTITUTION:
+            var_dna = get_mutation_type(match_obj["dna_change"])
+            ref_nt, alt_nt = (var_dna["ref"], var_dna["alt"])
+            if var_aa["subtype"] == VariantSubType.SUBSTITUTION:
                 ref_nt, alt_nt = get_nt_change(ref_nt, alt_nt)
 
             # cast to variant object
+            has_aa_change = all([len(var_aa["ref"]) == 1, len(var_aa["alt"]) == 1])
             variant = MykrobeVariant(
                 # classification
                 id=var_id,
-                variant_type=var_type,
-                variant_subtype=var_sub_type,
+                variant_type=var_aa["type"],
+                variant_subtype=var_aa["subtype"],
                 phenotypes=phenotype,
                 # location
-                reference_sequence=gene,
-                start=position,
-                end=position + len(alt_nt),
+                reference_sequence=match_obj["gene"],
+                start=var_dna["pos"],
+                end=var_dna["pos"] + len(alt_nt),
                 ref_nt=ref_nt,
                 alt_nt=alt_nt,
-                ref_aa=ref_aa if len(ref_aa) == 1 and len(alt_aa) == 1 else None,
-                alt_aa=alt_aa if len(ref_aa) == 1 and len(alt_aa) == 1 else None,
+                ref_aa=var_aa["ref"] if has_aa_change else None,
+                alt_aa=var_aa["alt"] if has_aa_change else None,
                 # variant info
                 method=element_type["genotype_model"],
-                depth=int(ref_depth) + int(alt_depth),
-                frequency=int(alt_depth) / (int(ref_depth) + int(alt_depth)),
-                confidence=int(conf),
+                depth=int(match_obj["ref_depth"]) + int(match_obj["alt_depth"]),
+                frequency=int(match_obj["alt_depth"])
+                / (int(match_obj["ref_depth"]) + int(match_obj["alt_depth"])),
+                confidence=int(match_obj["conf"]),
                 passed_qc=True,
             )
             results.append(variant)
@@ -143,7 +156,7 @@ def _parse_mykrobe_amr_variants(mykrobe_result) -> Tuple[MykrobeVariant, ...]:
     return variants
 
 
-def parse_mykrobe_amr_pred(prediction: Dict[str, Any]) -> AMRMethodIndex | None:
+def parse_mykrobe_amr_pred(prediction: dict[str, Any]) -> AMRMethodIndex | None:
     """Parse mykrobe resistance prediction results."""
     LOG.info("Parsing mykrobe prediction")
     resistance = ElementTypeResult(

--- a/prp/parse/phenotype/resfinder.py
+++ b/prp/parse/phenotype/resfinder.py
@@ -11,6 +11,8 @@ from ...models.phenotype import (
     ElementType,
     ElementTypeResult,
     PhenotypeInfo,
+    AMRMethodIndex,
+    StressMethodIndex,
 )
 from ...models.phenotype import PredictionSoftware as Software
 from ...models.phenotype import (
@@ -19,7 +21,6 @@ from ...models.phenotype import (
     VariantSubType,
     VariantType,
 )
-from ...models.sample import MethodIndex
 from ..utils import get_nt_change
 
 LOG = logging.getLogger(__name__)
@@ -356,7 +357,7 @@ def _parse_resfinder_amr_variants(
 
 def parse_resfinder_amr_pred(
     prediction: Dict[str, Any], resistance_category: ElementType
-) -> Tuple[SoupVersions, ElementTypeResult]:
+) -> AMRMethodIndex:
     """Parse resfinder resistance prediction results."""
     # resfinder missclassifies resistance the param amr_category by setting all to amr
     LOG.info("Parsing resistance prediction")
@@ -375,6 +376,11 @@ def parse_resfinder_amr_pred(
     resistance = ElementTypeResult(
         phenotypes=sr_profile, genes=res_genes, variants=res_mut
     )
-    return MethodIndex(
-        type=resistance_category, software=Software.RESFINDER, result=resistance
-    )
+    if resistance_category == ElementType.AMR:
+        return AMRMethodIndex(
+            type=resistance_category, software=Software.RESFINDER, result=resistance
+        )
+    else:
+        return StressMethodIndex(
+            type=resistance_category, software=Software.RESFINDER, result=resistance
+        )

--- a/prp/parse/phenotype/resfinder.py
+++ b/prp/parse/phenotype/resfinder.py
@@ -1,23 +1,22 @@
 """Parse resfinder results."""
 import logging
 from itertools import chain
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
-from ...models.metadata import SoupVersions
 from ...models.phenotype import (
+    AMRMethodIndex,
     AnnotationType,
     ElementAmrSubtype,
     ElementStressSubtype,
     ElementType,
     ElementTypeResult,
     PhenotypeInfo,
-    AMRMethodIndex,
-    StressMethodIndex,
 )
 from ...models.phenotype import PredictionSoftware as Software
 from ...models.phenotype import (
     ResfinderGene,
     ResfinderVariant,
+    StressMethodIndex,
     VariantSubType,
     VariantType,
 )
@@ -165,7 +164,9 @@ def lookup_antibiotic_class(antibiotic: str) -> str:
         "quinupristin": "streptogramin b",
         "pristinamycin ia": "streptogramin b",
         "virginiamycin s": "streptogramin b",
-        "unknown synthetic derivative of nicotinamide": "synthetic derivative of nicotinamide",
+        "unknown synthetic"
+        "derivative of nicotinamide": "synthetic derivative"
+        " of nicotinamide",
         "pyrazinamide": "synthetic derivative of nicotinamide",
         "unknown tetracycline": "tetracycline",
         "tetracycline": "tetracycline",
@@ -185,7 +186,7 @@ def lookup_antibiotic_class(antibiotic: str) -> str:
 
 
 def _assign_res_subtype(
-    prediction: Dict[str, Any], element_type: ElementType
+    prediction: dict[str, Any], element_type: ElementType
 ) -> ElementStressSubtype | None:
     """Assign element subtype from resfindere prediction."""
     assigned_subtype = None
@@ -224,7 +225,7 @@ def _get_resfinder_amr_sr_profie(resfinder_result, limit_to_phenotypes=None):
 
 def _parse_resfinder_amr_genes(
     resfinder_result, limit_to_phenotypes=None
-) -> List[ResfinderGene]:
+) -> list[ResfinderGene]:
     """Get resistance genes from resfinder result."""
     results = []
     for info in resfinder_result["seq_regions"].values():
@@ -284,7 +285,7 @@ def _parse_resfinder_amr_genes(
 
 def _parse_resfinder_amr_variants(
     resfinder_result, limit_to_phenotypes=None
-) -> Tuple[ResfinderVariant, ...]:
+) -> tuple[ResfinderVariant, ...]:
     """Get resistance genes from resfinder result."""
     # get prediction method
     prediction_method = None
@@ -356,7 +357,7 @@ def _parse_resfinder_amr_variants(
 
 
 def parse_resfinder_amr_pred(
-    prediction: Dict[str, Any], resistance_category: ElementType
+    prediction: dict[str, Any], resistance_category: ElementType
 ) -> AMRMethodIndex:
     """Parse resfinder resistance prediction results."""
     # resfinder missclassifies resistance the param amr_category by setting all to amr
@@ -380,7 +381,7 @@ def parse_resfinder_amr_pred(
         return AMRMethodIndex(
             type=resistance_category, software=Software.RESFINDER, result=resistance
         )
-    else:
-        return StressMethodIndex(
-            type=resistance_category, software=Software.RESFINDER, result=resistance
-        )
+
+    return StressMethodIndex(
+        type=resistance_category, software=Software.RESFINDER, result=resistance
+    )

--- a/prp/parse/phenotype/serotypefinder.py
+++ b/prp/parse/phenotype/serotypefinder.py
@@ -1,6 +1,6 @@
 """Functions for parsing serotypefinder result."""
 import logging
-from typing import Any, Dict
+from typing import Any
 
 from ...models.phenotype import ElementSerotypeSubtype, ElementType, SerotypeGene
 
@@ -8,7 +8,7 @@ LOG = logging.getLogger(__name__)
 
 
 def parse_serotype_gene(
-    info: Dict[str, Any],
+    info: dict[str, Any],
     subtype: ElementSerotypeSubtype = ElementSerotypeSubtype.ANTIGEN,
 ) -> SerotypeGene:
     """Parse serotype gene prediction results."""

--- a/prp/parse/phenotype/shigapass.py
+++ b/prp/parse/phenotype/shigapass.py
@@ -6,7 +6,7 @@ import re
 import numpy as np
 import pandas as pd
 
-from ...models.typing import TypingMethod, TypingResultShiga, ShigaTypingMethodIndex
+from ...models.typing import ShigaTypingMethodIndex, TypingMethod, TypingResultShiga
 from ...models.typing import TypingSoftware as Software
 
 LOG = logging.getLogger(__name__)

--- a/prp/parse/phenotype/shigapass.py
+++ b/prp/parse/phenotype/shigapass.py
@@ -2,20 +2,17 @@
 
 import logging
 import re
-from typing import List
 
 import numpy as np
 import pandas as pd
 
-from ...models.phenotype import ElementTypeResult
-from ...models.sample import MethodIndex
-from ...models.typing import TypingMethod, TypingResultShiga
+from ...models.typing import TypingMethod, TypingResultShiga, ShigaTypingMethodIndex
 from ...models.typing import TypingSoftware as Software
 
 LOG = logging.getLogger(__name__)
 
 
-def parse_shigapass_pred(path: str) -> ElementTypeResult:
+def parse_shigapass_pred(path: str) -> ShigaTypingMethodIndex:
     """Parse shigapass prediction results."""
     LOG.info("Parsing shigapass prediction")
     cols = {
@@ -36,7 +33,7 @@ def parse_shigapass_pred(path: str) -> ElementTypeResult:
         .replace(np.nan, None)
     )
     shigatype_results = _parse_shigapass_results(hits, 0)
-    return MethodIndex(
+    return ShigaTypingMethodIndex(
         type=TypingMethod.SHIGATYPE,
         result=shigatype_results,
         software=Software.SHIGAPASS,

--- a/prp/parse/phenotype/tbprofiler.py
+++ b/prp/parse/phenotype/tbprofiler.py
@@ -8,10 +8,10 @@ from ...models.phenotype import (
     ElementType,
     ElementTypeResult,
     PhenotypeInfo,
+    AMRMethodIndex,
 )
 from ...models.phenotype import PredictionSoftware as Software
 from ...models.phenotype import TbProfilerVariant, VariantSubType, VariantType
-from ...models.sample import MethodIndex
 
 LOG = logging.getLogger(__name__)
 
@@ -164,6 +164,6 @@ def parse_tbprofiler_amr_pred(
         genes=[],
         variants=_parse_tbprofiler_amr_variants(prediction),
     )
-    return MethodIndex(
+    return AMRMethodIndex(
         type=ElementType.AMR, software=Software.TBPROFILER, result=resistance
     )

--- a/prp/parse/phenotype/tbprofiler.py
+++ b/prp/parse/phenotype/tbprofiler.py
@@ -1,14 +1,14 @@
 """Parse TBprofiler result."""
 import logging
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 from ...models.metadata import SoupVersions
 from ...models.phenotype import (
+    AMRMethodIndex,
     AnnotationType,
     ElementType,
     ElementTypeResult,
     PhenotypeInfo,
-    AMRMethodIndex,
 )
 from ...models.phenotype import PredictionSoftware as Software
 from ...models.phenotype import TbProfilerVariant, VariantSubType, VariantType
@@ -48,7 +48,7 @@ def _get_tbprofiler_amr_sr_profie(tbprofiler_result):
     return {"susceptible": list(susceptible), "resistant": list(resistant)}
 
 
-def _parse_tbprofiler_amr_variants(predictions) -> Tuple[TbProfilerVariant, ...]:
+def _parse_tbprofiler_amr_variants(predictions) -> tuple[TbProfilerVariant, ...]:
     """Get resistance genes from tbprofiler result."""
     variant_caller = None
     for prog in predictions["pipeline"]["software"]:
@@ -114,13 +114,13 @@ def _parse_tbprofiler_amr_variants(predictions) -> Tuple[TbProfilerVariant, ...]
     return variants
 
 
-def parse_drug_resistance_info(drugs: List[Dict[str, str]]) -> List[PhenotypeInfo]:
+def parse_drug_resistance_info(drugs: list[dict[str, str]]) -> list[PhenotypeInfo]:
     """Parse drug info into the standard format.
 
     :param drugs: TbProfiler drug info
-    :type drugs: List[Dict[str, str]]
+    :type drugs: list[dict[str, str]]
     :return: Formatted phenotype info
-    :rtype: List[PhenotypeInfo]
+    :rtype: list[PhenotypeInfo]
     """
     phenotypes = []
     for drug in drugs:
@@ -155,8 +155,8 @@ def parse_drug_resistance_info(drugs: List[Dict[str, str]]) -> List[PhenotypeInf
 
 
 def parse_tbprofiler_amr_pred(
-    prediction: Dict[str, Any]
-) -> Tuple[SoupVersions, ElementTypeResult]:
+    prediction: dict[str, Any]
+) -> tuple[SoupVersions, ElementTypeResult]:
     """Parse tbprofiler resistance prediction results."""
     LOG.info("Parsing tbprofiler prediction")
     resistance = ElementTypeResult(

--- a/prp/parse/phenotype/virulencefinder.py
+++ b/prp/parse/phenotype/virulencefinder.py
@@ -1,17 +1,21 @@
 """Functions for parsing virulencefinder result."""
 import json
 import logging
-from typing import Any, Dict
+from typing import Any
 
-from ...models.phenotype import ElementType, VirulenceElementTypeResult, ElementVirulenceSubtype
+from ...models.phenotype import ElementType, ElementVirulenceSubtype
 from ...models.phenotype import PredictionSoftware as Software
-from ...models.phenotype import VirulenceGene, VirulenceMethodIndex
+from ...models.phenotype import (
+    VirulenceElementTypeResult,
+    VirulenceGene,
+    VirulenceMethodIndex,
+)
 
 LOG = logging.getLogger(__name__)
 
 
 def parse_vir_gene(
-    info: Dict[str, Any], subtype: ElementVirulenceSubtype = ElementVirulenceSubtype.VIR
+    info: dict[str, Any], subtype: ElementVirulenceSubtype = ElementVirulenceSubtype.VIR
 ) -> VirulenceGene:
     """Parse virulence gene prediction results."""
     start_pos, end_pos = map(int, info["position_in_ref"].split(".."))
@@ -73,7 +77,9 @@ def parse_virulencefinder_vir_pred(path: str) -> VirulenceElementTypeResult | No
     with open(path, "rb") as inpt:
         pred = json.load(inpt)
         if "virulencefinder" in pred:
-            results: VirulenceElementTypeResult = _parse_virulencefinder_vir_results(pred)
+            results: VirulenceElementTypeResult = _parse_virulencefinder_vir_results(
+                pred
+            )
             result = VirulenceMethodIndex(
                 type=ElementType.VIR, software=Software.VIRFINDER, result=results
             )

--- a/prp/parse/phenotype/virulencefinder.py
+++ b/prp/parse/phenotype/virulencefinder.py
@@ -3,10 +3,9 @@ import json
 import logging
 from typing import Any, Dict
 
-from ...models.phenotype import ElementType, ElementTypeResult, ElementVirulenceSubtype
+from ...models.phenotype import ElementType, VirulenceElementTypeResult, ElementVirulenceSubtype
 from ...models.phenotype import PredictionSoftware as Software
-from ...models.phenotype import VirulenceGene
-from ...models.sample import MethodIndex
+from ...models.phenotype import VirulenceGene, VirulenceMethodIndex
 
 LOG = logging.getLogger(__name__)
 
@@ -37,7 +36,7 @@ def parse_vir_gene(
     )
 
 
-def _parse_virulencefinder_vir_results(pred: str) -> ElementTypeResult:
+def _parse_virulencefinder_vir_results(pred: str) -> VirulenceElementTypeResult:
     """Parse virulence prediction results from virulencefinder."""
     # parse virulence finder results
     species = list(k for k in pred["virulencefinder"]["results"])
@@ -59,10 +58,10 @@ def _parse_virulencefinder_vir_results(pred: str) -> ElementTypeResult:
                 vir_genes.append(parse_vir_gene(gene, subtype))
     # sort genes
     genes = sorted(vir_genes, key=lambda entry: (entry.gene_symbol, entry.coverage))
-    return ElementTypeResult(genes=genes, phenotypes={}, variants=[])
+    return VirulenceElementTypeResult(genes=genes, phenotypes={}, variants=[])
 
 
-def parse_virulencefinder_vir_pred(path: str) -> ElementTypeResult | None:
+def parse_virulencefinder_vir_pred(path: str) -> VirulenceElementTypeResult | None:
     """Parse virulencefinder virulence prediction results.
 
     :param file: File name
@@ -74,8 +73,8 @@ def parse_virulencefinder_vir_pred(path: str) -> ElementTypeResult | None:
     with open(path, "rb") as inpt:
         pred = json.load(inpt)
         if "virulencefinder" in pred:
-            results: ElementTypeResult = _parse_virulencefinder_vir_results(pred)
-            result = MethodIndex(
+            results: VirulenceElementTypeResult = _parse_virulencefinder_vir_results(pred)
+            result = VirulenceMethodIndex(
                 type=ElementType.VIR, software=Software.VIRFINDER, result=results
             )
         else:

--- a/prp/parse/species.py
+++ b/prp/parse/species.py
@@ -1,7 +1,7 @@
 """Parsers for species prediction tools."""
 
 import logging
-from typing import Any, Dict, List
+from typing import Any
 
 import pandas as pd
 
@@ -39,7 +39,7 @@ def parse_kraken_result(file: str, cutoff: float = 0.0001) -> SppMethodIndex:
     )
 
 
-def get_mykrobe_spp_prediction(prediction: List[Dict[str, Any]]) -> SppMethodIndex:
+def get_mykrobe_spp_prediction(prediction: list[dict[str, Any]]) -> SppMethodIndex:
     """Get species prediction result from Mykrobe."""
     LOG.info("Parsing Mykrobe spp result.")
     spp_pred = MykrobeSpeciesPrediction(

--- a/prp/parse/typing.py
+++ b/prp/parse/typing.py
@@ -3,7 +3,6 @@
 import csv
 import json
 import logging
-from typing import List
 
 from ..models.sample import MethodIndex
 from ..models.typing import (
@@ -22,7 +21,7 @@ from .phenotype.virulencefinder import parse_vir_gene
 LOG = logging.getLogger(__name__)
 
 
-def _process_allele_call(allele: str) -> str | List[str] | None:
+def _process_allele_call(allele: str) -> str | list[str] | None:
     if allele.isdigit():
         result = int(allele)
     elif "," in allele:

--- a/prp/parse/utils.py
+++ b/prp/parse/utils.py
@@ -1,7 +1,6 @@
 """Shared utility functions."""
 import os
 from datetime import datetime
-from typing import Dict, List, Tuple
 
 from ..models.phenotype import (
     ElementType,
@@ -31,17 +30,17 @@ def is_prediction_result_empty(result: ElementTypeResult) -> bool:
     return n_entries == 0
 
 
-def get_nt_change(ref_codon: str, alt_codon: str) -> Tuple[str, str]:
+def get_nt_change(ref_codon: str, alt_codon: str) -> tuple[str, str]:
     """Get nucleotide change from codons
 
-    Ref: TCG, Alt: TTG => Tuple[C, T]
+    Ref: TCG, Alt: TTG => tuple[C, T]
 
     :param ref_codon: Reference codeon
     :type ref_codon: str
     :param str: Alternatve codon
     :type str: str
     :return: Returns nucleotide changed from the reference.
-    :rtype: Tuple[str, str]
+    :rtype: tuple[str, str]
     """
     ref_nt = ""
     alt_nt = ""
@@ -114,7 +113,7 @@ def _get_path(symlink_dir: str, subdir: str, filepath: str) -> str:
 
 def parse_input_dir(
     input_dir: str, jasen_dir: str, symlink_dir: str, output_dir: str
-) -> List[Dict[str, str]]:
+) -> list[dict[str, str]]:
     """Create a sample input array per sample in directory.
 
     :param input_dir: Input directory path
@@ -126,7 +125,7 @@ def parse_input_dir(
     :param output_dir: Output directory path
     :type output_dir: str
     :return: A list of sample arrays
-    :rtype: List[Dict[str, str]]
+    :rtype: list[dict[str, str]]
     """
     input_arrays = []
     input_dir = input_dir.rstrip("/")
@@ -153,7 +152,7 @@ def create_sample_array(
     sample_id: str,
     symlink_dir: str,
     output_dir: str,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     """Create an index wiht all sample files.
 
     :param species: species name
@@ -169,7 +168,7 @@ def create_sample_array(
     :param output_dir: Output directory
     :type output_dir: str
     :return: Collection of files used as input
-    :rtype: Dict[str, str]
+    :rtype: dict[str, str]
     """
     output = os.path.abspath(os.path.join(output_dir, f"{sample_id}_result.json"))
     bam = os.path.abspath(os.path.join(input_dir, f"bam/{sample_id}.bam"))

--- a/prp/parse/variant.py
+++ b/prp/parse/variant.py
@@ -2,7 +2,6 @@
 
 import logging
 import re
-from typing import List
 
 from cyvcf2 import VCF, Variant
 
@@ -60,7 +59,7 @@ def _get_variant_caller(vcf_obj: VCF) -> str | None:
     return None
 
 
-def load_variants(variant_file: str) -> List[VariantBase]:
+def load_variants(variant_file: str) -> list[VariantBase]:
     """Load variants."""
     vcf_obj = VCF(variant_file)
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,6 @@ addopts = "--cov --cov-report html --cov-report term-missing --cov-fail-under 95
 
 [tool.coverage.run]
 source = ["prp"]
+
+[tool.pylint.TYPECHECK]
+generated-members = "pysam.asTuple,pysam.TabixFile,pysam.AlignmentFile"

--- a/tests/parse/test_virulencefinder.py
+++ b/tests/parse/test_virulencefinder.py
@@ -1,9 +1,8 @@
 """Virulencefinder parser test suite."""
 # import pytest
 
-from prp.models.sample import MethodIndex
 from prp.models.typing import TypingResultGeneAllele
-from prp.parse.phenotype.virulencefinder import parse_virulencefinder_vir_pred
+from prp.parse.phenotype.virulencefinder import parse_virulencefinder_vir_pred, VirulenceMethodIndex
 from prp.parse.typing import parse_virulencefinder_stx_typing
 
 
@@ -13,7 +12,7 @@ def test_parse_virulencefinder_output(ecoli_virulencefinder_stx_pred_stx_path):
     result = parse_virulencefinder_vir_pred(ecoli_virulencefinder_stx_pred_stx_path)
 
     # test that result is method index
-    assert isinstance(result, MethodIndex)
+    assert isinstance(result, VirulenceMethodIndex)
     # test that all genes are identified
     assert len(result.result.genes) == 26
 

--- a/tests/parse/test_virulencefinder.py
+++ b/tests/parse/test_virulencefinder.py
@@ -2,7 +2,10 @@
 # import pytest
 
 from prp.models.typing import TypingResultGeneAllele
-from prp.parse.phenotype.virulencefinder import parse_virulencefinder_vir_pred, VirulenceMethodIndex
+from prp.parse.phenotype.virulencefinder import (
+    VirulenceMethodIndex,
+    parse_virulencefinder_vir_pred,
+)
 from prp.parse.typing import parse_virulencefinder_stx_typing
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,11 @@ import json
 from click.testing import CliRunner
 
 from prp.cli import annotate_delly, create_bonsai_input, create_cdm_input
+from prp.models import PipelineResult
+
+from typing import Literal
+from prp.models.base import RWModel
+from prp.models.phenotype import ElementType
 
 
 def test_create_output_saureus(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,12 @@
 """Test PRP cli functions."""
 
 import json
+from typing import Literal
 
 from click.testing import CliRunner
 
 from prp.cli import annotate_delly, create_bonsai_input, create_cdm_input
 from prp.models import PipelineResult
-
-from typing import Literal
 from prp.models.base import RWModel
 from prp.models.phenotype import ElementType
 
@@ -140,7 +139,7 @@ def test_create_output_ecoli(
         # test that the correct output was generated
         with open(output_file) as inpt:
             prp_output = json.load(inpt)
-        
+
         # get prediction softwares in ouptut
         prediction_sw = {res["software"] for res in prp_output["element_type_result"]}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,8 +61,16 @@ def test_create_output_saureus(
             prp_output = json.load(inpt)
         # get prediction softwares in ouptut
         prediction_sw = {res["software"] for res in prp_output["element_type_result"]}
-        # test that resfinder, amrfinder and virulence finder result is in output
+
+        # Test
+        # ====
+
+        # 1. that resfinder, amrfinder and virulence finder result is in output
         assert len({"resfinder", "amrfinder", "virulencefinder"} & prediction_sw) == 3
+
+        # 2. that the output datamodel can be used to format input data as well
+        output_data_model = PipelineResult(**prp_output)
+        assert prp_output == json.loads(output_data_model.model_dump_json())
 
 
 def test_create_output_ecoli(
@@ -127,10 +135,19 @@ def test_create_output_ecoli(
         # test that the correct output was generated
         with open(output_file) as inpt:
             prp_output = json.load(inpt)
+        
         # get prediction softwares in ouptut
         prediction_sw = {res["software"] for res in prp_output["element_type_result"]}
-        # test that resfinder, amrfinder and virulence finder result is in output
+
+        # Test
+        # ====
+
+        # 1. that resfinder, amrfinder and virulence finder result is in output
         assert len({"resfinder", "amrfinder", "virulencefinder"} & prediction_sw) == 3
+
+        # 2. that the output datamodel can be used to format input data as well
+        output_data_model = PipelineResult(**prp_output)
+        assert prp_output == json.loads(output_data_model.model_dump_json())
 
 
 def test_cdm_input_cmd(
@@ -243,5 +260,13 @@ def test_create_output_mtuberculosis(
             prp_output = json.load(inpt)
         # get prediction softwares in ouptut
         prediction_sw = {res["software"] for res in prp_output["element_type_result"]}
-        # test that resfinder, amrfinder and virulence finder result is in output
+
+        # Test
+        # ====
+
+        # 1. that resfinder, amrfinder and virulence finder result is in output
         assert len({"mykrobe", "tbprofiler"} & prediction_sw) == 2
+
+        # 2. that the output datamodel can be used to format input data as well
+        output_data_model = PipelineResult(**prp_output)
+        assert prp_output == json.loads(output_data_model.model_dump_json())


### PR DESCRIPTION
This PR fixes an issue where the pydantic picked the wrong data models when casting PRP output data into the `PipelineResult` data structure. This would cause issues for Bonsai.