### PR TITLE
Update how metadata are stored in bonsai input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,18 @@
  - Added flag to set verbosity level.
  - Validate TbProfiler schema version.
  - Added CLI command for adding IGV annotation tracks
+ - Added `indel_variants` to json result and ability to filter vcf into various categories
 
 ### Fixed
+
+ - Fixed genome_annotation appending bug
+ - Fixed variant sorting as `reference_sequence` can be None
 
 ### Changed
 
  - Updated sample metadata in the output format. RunMetadata was split into two fields, one for sequencing and one for pipeline information. Lims id and sample name are now included in the SampleBase object.
+ - Split SV and SNV from tbprofiler output
+ - Update annotate_delly to extract SVs from vcf
 
 ## [0.9.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Changed
 
+ - Updated sample metadata in the output format. RunMetadata was split into two fields, one for sequencing and one for pipeline information. Lims id and sample name are now included in the SampleBase object.
+
 ## [0.9.3]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 prp --help
 ```
 
-### Use the method help argument for information regarding the input for each of prp's methods (`create-bonsai-input`, `create-cdm-input`, `create-qc-result`, `print-schema`, `validate`)
+### Use the method help argument for information regarding the input for each of prp's methods (`add-igv-annotation-track`, `annotate-delly`, `create-bonsai-input`, `create-cdm-input`, `create-qc-result`, `print-schema`, `rerun-bonsai-input`, `validate`)
 ```
 prp <method> --help
 ```
@@ -33,4 +33,19 @@ prp create-cdm-input -q QUAST_FILENAME -c CGMLST_FILE -p POSTALIGNQC_FILE [--cor
 ### Create QC result from bam file
 ```
 prp create-qc-result -i SAMPLE_ID --b BAM_FILE [-e BED_FILE] [-a BAITS_FILE] -r REFERENCE_FILE [-c CPUS] -o OUTPUT_FILE [-h]
+```
+
+### Rerun bonsai input creation for all samples
+```
+prp rerun-bonsai-input -i INPUT_DIR  -j JASEN_DIR -s SYMLINK_DIR -o OUTPUT_DIR
+```
+
+### Add IGV annotation track to result
+```
+prp add-igv-annotation-track -n, TRACK_NAME -a, ANNOTATION_FILE -b, BONSAI_INPUT_FILE
+```
+
+### Validate output format of result json file
+```
+prp validate -o OUTPUT
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ prp <method> --help
 
 ### Create bonsai input from pipeline data
 ```
-prp create-bonsai-input -i SAMPLE_ID -u RUN_METADATA_FILE -q QUAST_FILENAME -d PROCESS_METADATA_FILE -k KRAKEN_FILE -a AMRFINDER_FILE -m MLST_FILE -c CGMLST_FILE -v VIRULENCEFINDER_FILE -r RESFINDER_FILE -p POSTALIGNQC_FILE -k MYKROBE_FILE -t TBPROFILER_FILE [--correct_alleles] -o OUTPUT_FILE [-h]
+prp create-bonsai-input -i SAMPLE_ID -u RUN_METADATA_FILE -q QUAST_FILENAME -d PROCESS_METADATA_FILE -k KRAKEN_FILE -a AMRFINDER_FILE -m MLST_FILE -c CGMLST_FILE -v VIRULENCEFINDER_FILE -r RESFINDER_FILE -p POSTALIGNQC_FILE -k MYKROBE_FILE -t TBPROFILER_FILE --vcf VCF_FILE [--snv-vcf SNV_VCF_FILE] [--sv-vcf SV_VCF_FILE] [--symlink-dir SYMLINK_DIR] [--correct_alleles] -o OUTPUT_FILE [-h]
 ```
 
 ### Create CDM input from pipeline data
@@ -37,15 +37,15 @@ prp create-qc-result -i SAMPLE_ID --b BAM_FILE [-e BED_FILE] [-a BAITS_FILE] -r 
 
 ### Rerun bonsai input creation for all samples
 ```
-prp rerun-bonsai-input -i INPUT_DIR  -j JASEN_DIR -s SYMLINK_DIR -o OUTPUT_DIR
+prp rerun-bonsai-input -i INPUT_DIR  -j JASEN_DIR -s SYMLINK_DIR -o OUTPUT_DIR -o OUTPUT_FILE [-h]
 ```
 
 ### Add IGV annotation track to result
 ```
-prp add-igv-annotation-track -n, TRACK_NAME -a, ANNOTATION_FILE -b, BONSAI_INPUT_FILE
+prp add-igv-annotation-track -n TRACK_NAME -a ANNOTATION_FILE -b BONSAI_INPUT_FILE -o OUTPUT_FILE [-h]
 ```
 
 ### Validate output format of result json file
 ```
-prp validate -o OUTPUT
+prp validate -o OUTPUT_FILE [-h]
 ```

--- a/prp/cli.py
+++ b/prp/cli.py
@@ -562,17 +562,18 @@ def annotate_delly(vcf, bed, output):
 )
 @click.argument("output", type=click.File("w"))
 def add_igv_annotation_track(track_name, annotation_file, bonsai_input_file, output):
-    """Add IGV annotation track to result."""
+    """Add IGV annotation track to result (bonsai input file)."""
     with open(bonsai_input_file, "r", encoding="utf-8") as jfile:
         result_obj = PipelineResult(**json.load(jfile))
+    print(result_obj.genome_annotation)
 
     # Get genome annotation
-    if result_obj.genome_annotation is None or isinstance(
+    if not isinstance(
         result_obj.genome_annotation, list
     ):
         track_info = []
     else:
-        track_info = bonsai_input_file.genome_annotation
+        track_info = result_obj.genome_annotation
 
     # add new tracks
     track_info.append({"name": track_name, "file": annotation_file})

--- a/prp/cli.py
+++ b/prp/cli.py
@@ -492,13 +492,20 @@ def create_qc_result(sample_id, bam, bed, baits, reference, cpus, output) -> Non
 @click.option("-v", "--vcf", type=click.Path(exists=True), help="VCF file")
 @click.option("-b", "--bed", type=click.Path(exists=True), help="BED file")
 @click.option(
+    "-b",
+    "--bonsai-input-file",
+    required=True,
+    type=click.Path(writable=True),
+    help="PRP result file (used as bonsai input).",
+)
+@click.option(
     "-o",
     "--output",
     required=True,
     type=click.Path(writable=True),
     help="output filepath",
 )
-def annotate_delly(vcf, bed, output):
+def annotate_delly(vcf, bed, bonsai_input_file, output):
     """Annotate Delly SV varinats with genes in BED file."""
     output = Path(output)
     # load annotation
@@ -542,9 +549,21 @@ def annotate_delly(vcf, bed, output):
     )
 
     # open vcf writer
-    writer = Writer(output.absolute(), vcf_obj)
-    annotate_delly_variants(writer, vcf_obj, annotation, annot_chrom=annot_chrom)
+    with open(bonsai_input_file, "r", encoding="utf-8") as jfile:
+        result_obj = PipelineResult(**json.load(jfile))
 
+    # Get genome annotation
+    if not isinstance(
+        result_obj.sv_variants, list
+    ):
+        sv_variants_info = []
+    else:
+        sv_variants_info = result_obj.sv_variants
+
+    sv_variants = annotate_delly_variants(vcf_obj, annotation, annot_chrom=annot_chrom)
+    sv_variants_info.extend(sv_variants)
+    upd_result = result_obj.model_copy(update={"sv_variants": sv_variants_info})
+    output.write(upd_result.model_dump_json(indent=3))
     click.secho(f"Wrote annotated delly variants to {output}", fg="green")
 
 
@@ -560,7 +579,13 @@ def annotate_delly(vcf, bed, output):
     type=click.Path(writable=True),
     help="PRP result file (used as bonsai input).",
 )
-@click.argument("output", type=click.File("w"))
+@click.option(
+    "-o",
+    "--output",
+    required=True,
+    type=click.Path(writable=True),
+    help="output filepath",
+)
 def add_igv_annotation_track(track_name, annotation_file, bonsai_input_file, output):
     """Add IGV annotation track to result (bonsai input file)."""
     with open(bonsai_input_file, "r", encoding="utf-8") as jfile:

--- a/prp/cli.py
+++ b/prp/cli.py
@@ -492,7 +492,7 @@ def create_qc_result(sample_id, bam, bed, baits, reference, cpus, output) -> Non
 @click.option("-v", "--vcf", type=click.Path(exists=True), help="VCF file")
 @click.option("-b", "--bed", type=click.Path(exists=True), help="BED file")
 @click.option(
-    "-b",
+    "-i",
     "--bonsai-input-file",
     required=True,
     type=click.Path(writable=True),

--- a/prp/cli.py
+++ b/prp/cli.py
@@ -327,10 +327,13 @@ def create_bonsai_input(
 
     # parse SNV and SV variants.
     if snv_vcf:
-        results["snv_variants"] = load_variants(snv_vcf)
+        results["snv_variants"] = load_variants(snv_vcf)["snv_variants"]
 
     if sv_vcf:
-        results["sv_variants"] = load_variants(sv_vcf)
+        results["sv_variants"] = load_variants(sv_vcf)["sv_variants"]
+
+    if vcf:
+        results.update(load_variants(vcf))
 
     # entries for reference genome and read mapping
     if all([bam, reference_genome_fasta, reference_genome_gff]):

--- a/prp/cli.py
+++ b/prp/cli.py
@@ -565,7 +565,6 @@ def add_igv_annotation_track(track_name, annotation_file, bonsai_input_file, out
     """Add IGV annotation track to result (bonsai input file)."""
     with open(bonsai_input_file, "r", encoding="utf-8") as jfile:
         result_obj = PipelineResult(**json.load(jfile))
-    print(result_obj.genome_annotation)
 
     # Get genome annotation
     if not isinstance(

--- a/prp/cli.py
+++ b/prp/cli.py
@@ -502,13 +502,11 @@ def create_qc_result(sample_id, bam, bed, baits, reference, cpus, output) -> Non
     "-o",
     "--output",
     required=True,
-    type=click.Path(writable=True),
+    type=click.File("w"),
     help="output filepath",
 )
 def annotate_delly(vcf, bed, bonsai_input_file, output):
     """Annotate Delly SV varinats with genes in BED file."""
-    output = Path(output)
-    # load annotation
     if bed is not None:
         annotation = pysam.TabixFile(bed, parser=pysam.asTuple())
     else:
@@ -564,7 +562,7 @@ def annotate_delly(vcf, bed, bonsai_input_file, output):
     sv_variants_info.extend(sv_variants)
     upd_result = result_obj.model_copy(update={"sv_variants": sv_variants_info})
     output.write(upd_result.model_dump_json(indent=3))
-    click.secho(f"Wrote annotated delly variants to {output}", fg="green")
+    click.secho(f"Wrote annotated delly variants to {output.name}", fg="green")
 
 
 @cli.command()
@@ -583,7 +581,7 @@ def annotate_delly(vcf, bed, bonsai_input_file, output):
     "-o",
     "--output",
     required=True,
-    type=click.Path(writable=True),
+    type=click.File("w"),
     help="output filepath",
 )
 def add_igv_annotation_track(track_name, annotation_file, bonsai_input_file, output):
@@ -608,4 +606,4 @@ def add_igv_annotation_track(track_name, annotation_file, bonsai_input_file, out
     # overwrite result
     output.write(upd_result.model_dump_json(indent=3))
 
-    click.secho(f"Wrote updated result to {output}", fg="green")
+    click.secho(f"Wrote updated result to {output.name}", fg="green")

--- a/prp/models/metadata.py
+++ b/prp/models/metadata.py
@@ -1,6 +1,7 @@
 """Metadata models."""
 from datetime import datetime
 from enum import Enum
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -22,35 +23,25 @@ class SoupVersion(BaseModel):
     type: SoupType
 
 
-class RunInformation(RWModel):
-    """Store information on a run how the run was conducted."""
+class SequencingInfo(RWModel):
+    """Information on the sample was sequenced."""
+
+    run_id: str
+    platform: str
+    instrument: Optional[str]
+    method: dict[str, str] = {}
+    date: datetime | None
+
+
+class PipelineInfo(RWModel):
+    """Information on the sample was analysed."""
 
     pipeline: str
     version: str
     commit: str
-    analysis_profile: str = Field(
-        ...,
-        alias="analysisProfile",
-        description="The analysis profile used when starting the pipeline",
-    )
-    configuration_files: list[str] = Field(
-        ..., alias="configurationFiles", description="Nextflow configuration used"
-    )
+    analysis_profile: str
+    configuration_files: list[str]
     workflow_name: str
-    sample_name: str
-    lims_id: str
-    sequencing_run: str
-    sequencing_platform: str
-    sequencing_type: str
     command: str
+    softwares: list[SoupVersion]
     date: datetime
-
-
-SoupVersions = list[SoupVersion]
-
-
-class RunMetadata(BaseModel):
-    """Run metadata"""
-
-    run: RunInformation
-    databases: SoupVersions

--- a/prp/models/phenotype.py
+++ b/prp/models/phenotype.py
@@ -31,6 +31,7 @@ class VariantType(str, Enum):
     SNV = "SNV"
     MNV = "MNV"
     SV = "SV"
+    INDEL = "INDEL"
     STR = "STR"
 
 

--- a/prp/models/phenotype.py
+++ b/prp/models/phenotype.py
@@ -215,7 +215,7 @@ class VariantBase(RWModel):
     phenotypes: list[PhenotypeInfo] = []
 
     # variant location
-    reference_sequence: str = Field(
+    reference_sequence: str | None = Field(
         ...,
         description="Reference sequence such as chromosome, gene or contig id.",
         alias="gene_symbol",
@@ -251,7 +251,7 @@ class MykrobeVariant(VariantBase):
 class TbProfilerVariant(VariantBase):
     """Container for TbProfiler variant information"""
 
-    variant_effect: str
+    variant_effect: str | None = None
     hgvs_nt_change: Optional[str] = Field(..., description="DNA change in HGVS format")
     hgvs_aa_change: Optional[str] = Field(
         ..., description="Protein change in HGVS format"

--- a/prp/models/sample.py
+++ b/prp/models/sample.py
@@ -5,7 +5,7 @@ from typing import Literal, Optional, Union
 from pydantic import Field
 
 from .base import RWModel
-from .metadata import RunMetadata
+from .metadata import SequencingInfo, PipelineInfo
 from .phenotype import (
     AMRMethodIndex,
     StressMethodIndex,
@@ -44,8 +44,17 @@ class SampleBase(RWModel):
     """Base datamodel for sample data structure"""
 
     sample_id: str = Field(..., alias="sampleId", min_length=3, max_length=100)
-    run_metadata: RunMetadata = Field(..., alias="runMetadata")
+    sample_name: str
+    lims_id: str
+
+    # metadata
+    sequencing: SequencingInfo
+    pipeline: PipelineInfo
+
+    # quality
     qc: list[QcMethodIndex] = Field(...)
+
+    # species identification
     species_prediction: list[SppMethodIndex] = Field(..., alias="speciesPrediction")
 
 

--- a/prp/models/sample.py
+++ b/prp/models/sample.py
@@ -90,6 +90,7 @@ class PipelineResult(SampleBase):
     # optional variant info
     snv_variants: Optional[list[VariantBase]] = None
     sv_variants: Optional[list[VariantBase]] = None
+    indel_variants: Optional[list[VariantBase]] = None
     # optional alignment info
     reference_genome: Optional[ReferenceGenome] = None
     read_mapping: Optional[str] = None

--- a/prp/parse/metadata.py
+++ b/prp/parse/metadata.py
@@ -1,10 +1,11 @@
 """Parse metadata passed to pipeline."""
 import json
 import logging
+from datetime import datetime
 
 from Bio import SeqIO
 
-from ..models.metadata import RunInformation, SoupVersion
+from ..models.metadata import PipelineInfo, SequencingInfo, SoupVersion
 
 LOG = logging.getLogger(__name__)
 
@@ -29,8 +30,22 @@ def get_database_info(process_metadata: list[str]) -> list[SoupVersion]:
     return db_info
 
 
-def parse_run_info(run_metadata: str) -> RunInformation:
-    """Parse nextflow analysis information
+def parse_sequence_date_from_run_id(run_id: str) -> datetime | None:
+    err_msg = 'Unrecognized format of run_id, sequence time cant be determined'
+    if '_' not in run_id:
+        LOG.warning(err_msg)
+        return None
+    # parse date string
+    try:
+        seq_date = datetime.strptime(run_id.split('_')[0], r'%y%m%d')
+    except ValueError:
+        LOG.warning(err_msg)
+        seq_date = None
+    return seq_date
+
+
+def parse_run_info(run_metadata: str, process_metadata: list[str]) -> tuple[SequencingInfo, PipelineInfo]:
+    """Parse nextflow analysis information.
 
     :param run_metadata: Nextflow analysis metadata in json format.
     :type run_metadata: str
@@ -39,8 +54,31 @@ def parse_run_info(run_metadata: str) -> RunInformation:
     """
     LOG.info("Parse run metadata.")
     with open(run_metadata, encoding="utf-8") as jsonfile:
-        run_info = RunInformation(**json.load(jsonfile))
-    return run_info
+        run_info = json.load(jsonfile)
+    # get sample info
+    sample_info = {"sample_name": run_info["sample_name"], "lims_id": run_info["lims_id"]}
+    # get sequencing info
+    seq_info = SequencingInfo(
+        run_id=run_info['sequencing_run'],
+        platform=run_info['sequencing_platform'],
+        instrument=None,
+        method={'method': run_info['sequencing_type']},
+        date=parse_sequence_date_from_run_id(run_info['sequencing_run'])
+    )
+    # get pipeline info
+    soup_versions = get_database_info(process_metadata)
+    pipeline_info = PipelineInfo(
+        pipeline=run_info['pipeline'],
+        version=run_info['version'],
+        commit=run_info['commit'],
+        analysis_profile=run_info['analysis_profile'],
+        configuration_files=run_info['configuration_files'],
+        workflow_name=run_info['commit'],
+        command=run_info['command'],
+        softwares=soup_versions,
+        date=datetime.fromisoformat(run_info['date']),
+    )
+    return sample_info, seq_info, pipeline_info
 
 
 def get_gb_genome_version(fasta_path: str) -> str:

--- a/prp/parse/phenotype/mykrobe.py
+++ b/prp/parse/phenotype/mykrobe.py
@@ -45,36 +45,40 @@ def get_mutation_type(var_nom: str) -> tuple[str, Union[VariantSubType, str, int
 
     :param var_nom: Mykrobe mutation description
     :type var_nom: str
-    :return: Return variant type, ref_codon, alt_codont and position
+    :return: Return variant type, ref_nt, alt_ntt and position
     :rtype: dict[str, Union[VariantSubType, str, int]]
     """
     mut_type = None
-    ref_codon = None
-    alt_codon = None
+    ref_nt = None
+    alt_nt = None
     position = None
     try:
         ref_idx = re.search(r"\d", var_nom, 1).start()
         alt_idx = re.search(r"\d(?=[^\d]*$)", var_nom).start() + 1
     except AttributeError:
-        return mut_type, ref_codon, alt_codon, position
+        return mut_type, ref_nt, alt_nt, position
 
-    ref_codon = var_nom[:ref_idx]
-    alt_codon = var_nom[alt_idx:]
+    ref_nt = var_nom[:ref_idx]
+    alt_nt = var_nom[alt_idx:]
     position = int(var_nom[ref_idx:alt_idx])
-    if len(ref_codon) > len(alt_codon):
+    var_len = abs(len(ref_nt) - len(alt_nt))
+    if var_len >= 50:
         var_type = VariantType.SV
-        var_sub_type = VariantSubType.DELETION
-    elif len(ref_codon) < len(alt_codon):
-        var_type = VariantType.SV
-        var_sub_type = VariantSubType.INSERTION
+    elif 1 < var_len < 50:
+        var_type = VariantType.INDEL
     else:
         var_type = VariantType.SNV
+    if len(ref_nt) > len(alt_nt):
+        var_sub_type = VariantSubType.DELETION
+    elif len(ref_nt) < len(alt_nt):
+        var_sub_type = VariantSubType.INSERTION
+    else:
         var_sub_type = VariantSubType.SUBSTITUTION
     return {
         "type": var_type,
         "subtype": var_sub_type,
-        "ref": ref_codon,
-        "alt": alt_codon,
+        "ref": ref_nt,
+        "alt": alt_nt,
         "pos": position,
     }
 

--- a/prp/parse/phenotype/tbprofiler.py
+++ b/prp/parse/phenotype/tbprofiler.py
@@ -75,6 +75,13 @@ def _parse_tbprofiler_amr_variants(predictions) -> tuple[TbProfilerVariant, ...]
             ref_nt = hit["ref"]
             alt_nt = hit["alt"]
             var_type = VariantType.SNV if not bool(hit["sv"]) else VariantType.SV
+            var_len = abs(len(ref_nt) - len(alt_nt))
+            if var_len >= 50 or bool(hit["sv"]):
+                var_type = VariantType.SV
+            elif 1 < var_len < 50:
+                var_type = VariantType.INDEL
+            else:
+                var_type = VariantType.SNV
             if len(ref_nt) == len(alt_nt):
                 var_sub_type = VariantSubType.SUBSTITUTION
             elif len(ref_nt) > len(alt_nt):

--- a/prp/parse/phenotype/tbprofiler.py
+++ b/prp/parse/phenotype/tbprofiler.py
@@ -74,7 +74,7 @@ def _parse_tbprofiler_amr_variants(predictions) -> tuple[TbProfilerVariant, ...]
         for hit in predictions.get(result_type, []):
             ref_nt = hit["ref"]
             alt_nt = hit["alt"]
-            var_type = VariantType.SNV
+            var_type = VariantType.SNV if not bool(hit["sv"]) else VariantType.SV
             if len(ref_nt) == len(alt_nt):
                 var_sub_type = VariantSubType.SUBSTITUTION
             elif len(ref_nt) > len(alt_nt):

--- a/prp/parse/phenotype/tbprofiler.py
+++ b/prp/parse/phenotype/tbprofiler.py
@@ -2,7 +2,7 @@
 import logging
 from typing import Any
 
-from ...models.metadata import SoupVersions
+from ...models.metadata import SoupVersion
 from ...models.phenotype import (
     AMRMethodIndex,
     AnnotationType,
@@ -157,7 +157,7 @@ def parse_drug_resistance_info(drugs: list[dict[str, str]]) -> list[PhenotypeInf
 
 def parse_tbprofiler_amr_pred(
     prediction: dict[str, Any]
-) -> tuple[SoupVersions, ElementTypeResult]:
+) -> tuple[tuple[SoupVersion, ...], ElementTypeResult]:
     """Parse tbprofiler resistance prediction results."""
     LOG.info("Parsing tbprofiler prediction")
     resistance = ElementTypeResult(

--- a/prp/parse/variant.py
+++ b/prp/parse/variant.py
@@ -6,6 +6,7 @@ import re
 from cyvcf2 import VCF, Variant
 
 from prp.models.phenotype import VariantBase, VariantType
+from prp.models.phenotype import TbProfilerVariant, VariantBase, VariantType
 
 LOG = logging.getLogger(__name__)
 SOURCE_PATTERN = r"##source=(.+)\n"
@@ -80,27 +81,63 @@ def load_variants(variant_file: str) -> list[VariantBase]:
     return variants
 
 
-def annotate_delly_variants(writer, vcf, annotation, annot_chrom=False):
+def annotate_delly_variants(vcf, annotation, annot_chrom=False):
     """Annotate a variant called by Delly."""
+    results = []
+    var_id = 1
     locus_tag = 3
     gene_symbol = 4
     # annotate variant
     n_annotated = 0
     for variant in vcf:
-        # update chromosome
-        if annot_chrom:
-            variant.CHROM = annotation.contigs[0]
-        # get genes intersecting with SV
-        genes = [
-            {"gene_symbol": gene[gene_symbol], "locus_tag": gene[locus_tag]}
-            for gene in annotation.fetch(variant.CHROM, variant.start, variant.end)
-        ]
-        # add overlapping genes to INFO
-        if len(genes) > 0:
-            variant.INFO["gene"] = ",".join([gene["gene_symbol"] for gene in genes])
-            variant.INFO["locus_tag"] = ",".join([gene["locus_tag"] for gene in genes])
-            n_annotated += 1
+        var_sub_type = variant.INFO.get('TYPE').upper() if variant.INFO.get('TYPE') else variant.INFO.get('SVTYPE')
+        if var_sub_type == "DEL" or var_sub_type == "INS":
+            # update chromosome
+            if annot_chrom:
+                variant.CHROM = annotation.contigs[0]
+            # get genes intersecting with SV
+            genes = [
+                {"gene_symbol": gene[gene_symbol], "locus_tag": gene[locus_tag]}
+                for gene in annotation.fetch(variant.CHROM, variant.start, variant.end)
+            ]
+            # add overlapping genes to INFO
+            if len(genes) > 0:
+                variant.INFO["gene"] = ",".join([gene["gene_symbol"] for gene in genes])
+                variant.INFO["locus_tag"] = ",".join([gene["locus_tag"] for gene in genes])
+                n_annotated += 1
 
-        # write variant
-        writer.write_record(variant)
+            if len(variant.FILTERS) == 0:
+                passed_qc = None
+            elif "PASS" in variant.FILTERS:
+                passed_qc = True
+            else:
+                passed_qc = False
+            print(variant.CHROM, type(variant.start), type(variant.end))
+            print(genes)
+            var = TbProfilerVariant(
+                    id=var_id,
+                    variant_type=VariantType.SV,
+                    variant_subtype=var_sub_type,
+                    phenotypes=[],
+                    reference_sequence=variant.INFO.get("gene"),
+                    accession=variant.INFO.get("locus_tag"),
+                    start=variant.start,
+                    end=variant.end + len(variant.ALT),
+                    ref_nt=variant.REF,
+                    alt_nt=variant.ALT[0],
+                    variant_effect=None,
+                    hgvs_nt_change=None,
+                    hgvs_aa_change=None,
+                    depth=variant.INFO.get("DP"),
+                    frequency=variant.INFO.get("AF"),
+                    method="delly",
+                    passed_qc=passed_qc,
+                )
+            var_id += 1  # increment variant id
+            results.append(var)
+
+    variants = sorted(
+        results, key=lambda entry: (entry.reference_sequence, entry.start)
+    )
     LOG.info("Annotated %d SV variants", n_annotated)
+    return variants

--- a/prp/parse/variant.py
+++ b/prp/parse/variant.py
@@ -112,8 +112,6 @@ def annotate_delly_variants(vcf, annotation, annot_chrom=False):
                 passed_qc = True
             else:
                 passed_qc = False
-            print(variant.CHROM, type(variant.start), type(variant.end))
-            print(genes)
             var = TbProfilerVariant(
                     id=var_id,
                     variant_type=VariantType.SV,
@@ -137,7 +135,7 @@ def annotate_delly_variants(vcf, annotation, annot_chrom=False):
             results.append(var)
 
     variants = sorted(
-        results, key=lambda entry: (entry.reference_sequence, entry.start)
+        results, key=lambda entry: entry.start
     )
     LOG.info("Annotated %d SV variants", n_annotated)
     return variants

--- a/prp/parse/variant.py
+++ b/prp/parse/variant.py
@@ -16,7 +16,7 @@ def _filter_variants(variant_list):
     # Initialize the results dictionary
     filetered_variants = {
         'sv_variants': [],
-        'mnv_variants': [],
+        'indel_variants': [],
         'snv_variants': []
     }
 
@@ -26,8 +26,8 @@ def _filter_variants(variant_list):
         # Append the variant to the appropriate key in the results dictionary
         if variant_type == "SV":
             filetered_variants['sv_variants'].append(variant)
-        elif variant_type == "MNV":
-            filetered_variants['mnv_variants'].append(variant)
+        elif variant_type == "INDEL":
+            filetered_variants['indel_variants'].append(variant)
         elif variant_type == "SNV":
             filetered_variants['snv_variants'].append(variant)
     return filetered_variants
@@ -41,7 +41,7 @@ def _get_variant_type(variant) -> VariantType:
         case "mnp":
             var_type = VariantType.MNV
         case "indel":
-            var_type = VariantType.SV
+            var_type = VariantType.INDEL
         case _:
             var_type = VariantType(variant.var_type.upper())
     return var_type

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 from .fixtures import *
 from prp.models import PipelineResult
-from prp.models.metadata import RunMetadata, RunInformation
+from prp.models.metadata import PipelineInfo, SequencingInfo
 from datetime import datetime
 
 
@@ -10,26 +10,30 @@ from datetime import datetime
 def simple_pipeline_result():
     """Return a basic analysis result."""
 
-    mock_run_info = RunInformation(
+    mock_pipeline_info = PipelineInfo(
         pipeline="Jasen",
         version="0.0.1",
         commit="commit-hash",
         analysis_profile="",
         configuration_files=[],
         workflow_name="workflow-name",
-        sample_name="sample-name",
-        lims_id="limbs id",
-        sequencing_run="run-id",
-        sequencing_platform="sequencing plattform",
-        sequencing_type="illumina",
         command="nextflow run ...",
+        softwares=[],
         date=datetime.now(),
     )
+    seq_info = SequencingInfo(
+        run_id="run-id",
+        platform="sequencing plattform",
+        instrument="illumina",
+        date=datetime.now()
+    )
     # add run into to metadata model
-    metadata = RunMetadata(run=mock_run_info, databases=[])
     return PipelineResult(
         sample_id="mock-sample-001",
-        run_metadata=metadata,
+        sample_name="sample-name",
+        lims_id="limbs id",
+        sequencing=seq_info,
+        pipeline=mock_pipeline_info,
         qc=[],
         species_prediction=[],
         typing_result=[],

--- a/tests/parse/test_variant.py
+++ b/tests/parse/test_variant.py
@@ -6,11 +6,11 @@ def test_parse_sv_variants(mtuberculosis_sv_vcf_path):
     """Test loading of varians."""
 
     variants = load_variants(mtuberculosis_sv_vcf_path)
-    assert len(variants) == 2
+    assert len(variants) == 3
 
 
 def test_parse_snv_variants(mtuberculosis_snv_vcf_path):
     """Test loading of varians."""
 
     variants = load_variants(mtuberculosis_snv_vcf_path)
-    assert len(variants) == 2
+    assert len(variants) == 3

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -238,6 +238,7 @@ def test_add_igv_annotation_track(mtuberculosis_snv_vcf_path, simple_pipeline_re
             mtuberculosis_snv_vcf_path,
             "--bonsai-input-file",
             result_fname,
+            "--output",
             output_fname,
         ]
         result = runner.invoke(add_igv_annotation_track, args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -232,11 +232,11 @@ def test_add_igv_annotation_track(mtuberculosis_snv_vcf_path, simple_pipeline_re
 
         output_fname = "after_update.json"
         args = [
-            "--name",
+            "--track-name",
             "snv",
             "--annotation-file",
             mtuberculosis_snv_vcf_path,
-            "--result",
+            "--bonsai-input-file",
             result_fname,
             output_fname,
         ]


### PR DESCRIPTION
This PR makes changes to the output data format. 

- RunMetadata has been split into two seperate data classes, one for recording sequencing information and the other for information on the pipeline.
- LIMS id and sample name was moved from RunMetadata into the SampleBase object, which makes more sense.
- Split SV and SNV from tbprofiler output
- Update annotate_delly to extract SVs from vcf
- Fix genome_annotation appending bug
- Fix variant sorting as `reference_sequence` can be None
- Add `indel_variants` to json result and ability to filter vcf into various categories