### PR TITLE
Update to v1.3.3-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,9 @@
 
 ### Fixed
 
- - Fixed missing parsing of vcf file
-
 ### Changed
 
-## [1.3.3-alpha.1]
+## [1.3.3-beta.1]
 
 ### Added
 
@@ -21,6 +19,7 @@
  - Replaced `NA` with `None` when `gambitcore` returns no hits
  - Fixed chewbbaca parser log printing every non-integer call
  - Fixed multiple hits `mykrobe` bug
+ - Fixed missing parsing of vcf file
 
 ### Changed
 

--- a/prp/__version__.py
+++ b/prp/__version__.py
@@ -1,3 +1,3 @@
 """PRP version"""
 
-VERSION = "1.3.3-alpha.1"
+VERSION = "1.3.3-beta.1"


### PR DESCRIPTION
## [1.3.3-beta.1]

### Added

 - Created function extract accession from reference fasta header
 - Added genome fasta files for igv accn parsing in pytests
 - Added gff and sig files for pytests

### Fixed

 - Replaced `NA` with `None` when `gambitcore` returns no hits
 - Fixed chewbbaca parser log printing every non-integer call
 - Fixed multiple hits `mykrobe` bug
 - Fixed missing parsing of vcf file

### Changed

 - Changed config model making `gambitcore` filepath optional
 - Changed `GambitcoreQcResult` model regarding expected `gambitcore` output
