### PR TITLE
Fixed wrong field alias for field n_missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Changed alias for `TypingResultCgMlst.n_missing` to `nMissing`
+
 ### Changed
 - Made variant input opional for creation of .json file
 - Updated prp commands in readme

--- a/prp/models/typing.py
+++ b/prp/models/typing.py
@@ -78,7 +78,7 @@ class TypingResultCgMlst(ResultMlstBase):
     """MLST results"""
 
     n_novel: int = Field(0, alias="nNovel")
-    n_missing: int = Field(0, alias="nNovel")
+    n_missing: int = Field(0, alias="nMissing")
 
 
 class TypingResultShiga(RWModel):


### PR DESCRIPTION
Changes `n_missing` field alias from nAlleles to nMissing.

close #194 