### PR TITLE
Add functions for registering and hydrating parser models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- Added a result model registry and function for casting JSON results to a result data model.
 - Added APIs for registering and excecuting parses from the input software name and version.
 - Added parser registry with support for version based parser selection.
 - Added added tests for several existing parsers

--- a/prp/models/enums.py
+++ b/prp/models/enums.py
@@ -50,7 +50,7 @@ class AnalysisType(StrEnum):
     SHIGATYPE = "shigatype"
     SMST = "smst"
     SPATYPE = "spatype"
-    SPECIES = "species"
+    SPECIES = "species_prediction"
     STRESS = "stress"
     STX = "stx"
     TYPING = "typing"

--- a/prp/parse/__init__.py
+++ b/prp/parse/__init__.py
@@ -3,19 +3,9 @@
 from importlib import import_module
 from pathlib import Path
 
-from .core.registry import register_parser, run_parser, get_parser, hydrate_result, register_result_model
-
 # auto-import all modules under parse/parsers to ensure that all parsers are registered
 PARSER_DIR = "parsers"
 _pkg_dir = Path(__file__).parent.joinpath(PARSER_DIR)
 for file in _pkg_dir.glob("*.py"):
     if file.name not in ("__init__.py", "utils.py"):
         import_module(f"{__name__}.{PARSER_DIR}.{file.stem}")
-
-__all__ = [
-    "register_parser",
-    "run_parser", 
-    "get_parser",
-    "hydrate_result",
-    "register_result_model",
-]

--- a/prp/parse/__init__.py
+++ b/prp/parse/__init__.py
@@ -2,7 +2,7 @@
 
 from importlib import import_module
 from pathlib import Path
-from .core.registry import get_parser, registered_softwares, registered_version_ranges, run_parser
+from .core.registry import get_parser, registered_softwares, registered_version_ranges, run_parser, hydrate_result
 
 # auto-import all modules under parse/parsers to ensure that all parsers are registered
 PARSER_DIR = "parsers"
@@ -11,4 +11,4 @@ for file in _pkg_dir.glob("*.py"):
     if file.name not in ("__init__.py", "utils.py"):
         import_module(f"{__name__}.{PARSER_DIR}.{file.stem}")
 
-__all__ = ["get_parser", "registered_softwares", "registered_version_ranges", "run_parser"]
+__all__ = ["get_parser", "registered_softwares", "registered_version_ranges", "run_parser", "hydrate_result"]

--- a/prp/parse/__init__.py
+++ b/prp/parse/__init__.py
@@ -2,6 +2,7 @@
 
 from importlib import import_module
 from pathlib import Path
+from .core.registry import get_parser, registered_softwares, registered_version_ranges, run_parser
 
 # auto-import all modules under parse/parsers to ensure that all parsers are registered
 PARSER_DIR = "parsers"
@@ -9,3 +10,5 @@ _pkg_dir = Path(__file__).parent.joinpath(PARSER_DIR)
 for file in _pkg_dir.glob("*.py"):
     if file.name not in ("__init__.py", "utils.py"):
         import_module(f"{__name__}.{PARSER_DIR}.{file.stem}")
+
+__all__ = ["get_parser", "registered_softwares", "registered_version_ranges", "run_parser"]

--- a/prp/parse/__init__.py
+++ b/prp/parse/__init__.py
@@ -3,7 +3,7 @@
 from importlib import import_module
 from pathlib import Path
 
-from .core.registry import run_parser
+from .core.registry import register_parser, run_parser, get_parser, hydrate_result, register_result_model
 
 # auto-import all modules under parse/parsers to ensure that all parsers are registered
 PARSER_DIR = "parsers"
@@ -11,3 +11,11 @@ _pkg_dir = Path(__file__).parent.joinpath(PARSER_DIR)
 for file in _pkg_dir.glob("*.py"):
     if file.name not in ("__init__.py", "utils.py"):
         import_module(f"{__name__}.{PARSER_DIR}.{file.stem}")
+
+__all__ = [
+    "register_parser",
+    "run_parser", 
+    "get_parser",
+    "hydrate_result",
+    "register_result_model",
+]

--- a/prp/parse/core/base.py
+++ b/prp/parse/core/base.py
@@ -14,7 +14,6 @@ from prp.parse.core.envelope import (
     run_as_envelope,
 )
 from prp.parse.exceptions import UnsupportedAnalysisTypeError
-from prp.parse.models.base import ParseImplOut, ParserOutput, ResultEnvelope
 from prp.parse.models.enums import AnalysisType, ResultStatus
 
 T = TypeVar("T")
@@ -52,7 +51,7 @@ class BaseParser(ABC):
         want: set[AnalysisType] | AnalysisType | None = None,
         software_version: str | None = None,
         **kwargs: Any,
-    ) -> ParserOutput:
+    ) -> "ParserOutput":
         """Parse a source into structured results."""
         want: set[AnalysisType] = self._normalize_want(want)
 
@@ -100,8 +99,11 @@ class BaseParser(ABC):
         want = want or set(self.produces)
         return {want} if isinstance(want, AnalysisType) else want
 
-    def _new_output(self, software_version: str | None) -> ParserOutput:
+    def _new_output(self, software_version: str | None) -> "ParserOutput":
         """Create a new output model."""
+        # lazy load to avoid circular imports
+        from prp.parse.models.base import ParserOutput
+
         return ParserOutput(
             software=self.software,
             software_version=software_version,
@@ -208,7 +210,7 @@ class BaseParser(ABC):
         *,
         want: set[AnalysisType],
         **kwargs: Any,
-    ) -> ParseImplOut:
+    ) -> "ParseImplOut":
         """Return results keyed by analysis_type."""
 
 
@@ -290,6 +292,9 @@ def parse_child(
     parser: BaseParser, source: StreamOrPath, atype: AnalysisType, *, strict: bool
 ) -> Any:
     """Utility to call another parser inside a parser."""
+
+    # lazy load deps to avoid circular imports
+    from prp.parse.models.base import ResultEnvelope
 
     child = parser.parse(source, want={atype}, strict=strict)
     env = child.results.get(atype)

--- a/prp/parse/core/envelope.py
+++ b/prp/parse/core/envelope.py
@@ -4,7 +4,6 @@ from logging import Logger
 from typing import Any, Callable, TypeVar
 
 from prp.parse.exceptions import AbsentResultError, ParserError
-from prp.parse.models.base import ResultEnvelope
 from prp.parse.models.enums import ResultStatus
 
 PredicateFn = Callable[[Any], bool]
@@ -27,31 +26,35 @@ def envelope_from_value(
     empty_predicate: PredicateFn = default_empty_predicate,
     reason: str | None = None,
     meta: dict[str, Any] | None = None,
-) -> ResultEnvelope:
+) -> "ResultEnvelope":
     """Create a PARSED/ EMPTY envelope based on the provided result."""
 
     status = ResultStatus.EMPTY if empty_predicate(value) else ResultStatus.PARSED
+    from prp.parse.models.base import ResultEnvelope
     return ResultEnvelope(status=status, value=value, reason=reason, meta=meta or {})
 
 
 def envelope_error(
     reason: str, *, meta: dict[str, Any] | None = None
-) -> ResultEnvelope:
+) -> "ResultEnvelope":
     """Create an envelope that signifies that an error occured."""
+    from prp.parse.models.base import ResultEnvelope
     return ResultEnvelope(status=ResultStatus.ERROR, reason=reason, meta=meta or {})
 
 
 def envelope_absent(
     reason: str, *, meta: dict[str, Any] | None = None
-) -> ResultEnvelope:
+) -> "ResultEnvelope":
     """Create an envelope that for result being absent in the input file."""
+    from prp.parse.models.base import ResultEnvelope
     return ResultEnvelope(status=ResultStatus.ABSENT, reason=reason, meta=meta or {})
 
 
 def envelope_skipped(
     reason: str = "Omitted by user", *, meta: dict[str, Any] | None = None
-) -> ResultEnvelope:
+) -> "ResultEnvelope":
     """Create an envelope that signifies that the result was skipped by the user."""
+    from prp.parse.models.base import ResultEnvelope
     return ResultEnvelope(status=ResultStatus.SKIPPED, reason=reason, meta=meta or {})
 
 
@@ -65,7 +68,7 @@ def run_as_envelope(
     reason_if_empty: str | None = None,
     meta: dict[str, Any] | None = None,
     logger: Logger | None = None,
-) -> ResultEnvelope:
+) -> "ResultEnvelope":
     """Execute a parser function and wrap it in a ResultEnvelope."""
     base_meta = {**(meta or {}), "step": analysis_name}
     try:
@@ -111,4 +114,6 @@ def run_as_envelope(
     if empty_predicate(value):
         status = ResultStatus.EMPTY
         reason = reason_if_empty or None
+
+    from prp.parse.models.base import ResultEnvelope
     return ResultEnvelope(status=status, value=value, reason=reason, meta=base_meta)

--- a/prp/parse/core/registry.py
+++ b/prp/parse/core/registry.py
@@ -32,7 +32,7 @@ class VersionRange(Generic[TEntry]):
 
 
 _PARSER_REGISTRY: dict[str, list[VersionRange[ParserRegistryEntry]]] = {}
-_RESULT_MODEL_REGISTRY: dict[tuple[AnalysisSoftware, AnalysisType], list[VersionRange[ModelClass]]] = {}
+_RESULT_MODEL_REGISTRY: dict[tuple[AnalysisSoftware, AnalysisType], ModelClass] = {}
 
 
 def _normalize_version(version: str | Version) -> Version:
@@ -139,29 +139,15 @@ def run_parser(
 def register_result_model(
     software: str | AnalysisSoftware,
     analysis_type: str | AnalysisType,
-    *,
-    min_version: str | None = None,
-    max_version: str | None = None,
 ):
-    """Decorator to register a result model for a range of software versions.
-
-    Null values mean either undefined or 'no upper limit'.
-    """
-    min_version = min_version or "0.0.0"
-    max_version = max_version or "99999.0.0"
-
+    """Decorator to register a result model."""
     # Normalise to string keys to keep the registry consistent
     software_key = str(software)
     analysis_type_key = str(analysis_type)
 
     def wrapper(cls: ModelClass) -> ModelClass:
-        v_range = VersionRange(
-            min_version=Version(min_version),
-            max_version=Version(max_version),
-            entry=cls,
-        )
         key = (software_key, analysis_type_key)
-        _RESULT_MODEL_REGISTRY.setdefault(key, []).append(v_range)
+        _RESULT_MODEL_REGISTRY.setdefault(key, cls)
         return cls
 
     return wrapper
@@ -170,29 +156,20 @@ def register_result_model(
 def get_result_model(
     software: str | AnalysisSoftware,
     analysis_type: str | AnalysisType,
-    *,
-    version: str,
 ) -> ModelClass | None:
     """Return the registered result model class for software/type/version, or None."""
     software_key = str(software)
     analysis_type_key = str(analysis_type)
     key = (software_key, analysis_type_key)
 
-    ranges = _RESULT_MODEL_REGISTRY.get(key)
-    if not ranges:
-        return None  # No result model registered for this software/type
+    model_cls = _RESULT_MODEL_REGISTRY.get(key)
+    if model_cls:
+        return model_cls
 
-    v = _normalize_version(version)
-
-    for span in sorted(ranges):
-        if span.min_version <= v <= span.max_version:
-            return span.entry
-
-    # Version not supported → None; let caller decide how to handle
-    return None
+    return None  # No result model registered for this software/type
 
 
-def hydrate_result(*, software: str, software_version: str, analysis_type: str, result: dict) -> Any:
+def hydrate_result(*, software: str, analysis_type: str, result: dict) -> Any:
     """Hydrate json data into a typed result object or raw data if unknown."""
     if not isinstance(result, dict):
         raise ValueError("Expected a dictionary to hydrate the result object.")
@@ -200,7 +177,6 @@ def hydrate_result(*, software: str, software_version: str, analysis_type: str, 
     model_cls = get_result_model(
         software=software,
         analysis_type=analysis_type,
-        version=software_version,
     )
     if model_cls is None:
         return result

--- a/prp/parse/core/registry.py
+++ b/prp/parse/core/registry.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Generic, TypeAlias, TypeVar
 
 from packaging.version import InvalidVersion, Version
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
 
 from prp.parse.core.base import BaseParser, StreamOrPath
 from prp.parse.exceptions import (
@@ -213,5 +213,10 @@ def hydrate_result(*, software: str, analysis_type: str, result: dict) -> Any:
     )
     if model_cls is None:
         return result
-
-    return model_cls.model_validate(result)
+    
+    if isinstance(model_cls, TypeAdapter):
+        return model_cls.validate_python(result)
+    elif issubclass(model_cls, BaseModel):
+        return model_cls.model_validate(result)
+    
+    raise TypeError(f"Unsupported model class type for hydration: {type(model_cls).__name__}")

--- a/prp/parse/core/registry.py
+++ b/prp/parse/core/registry.py
@@ -32,6 +32,7 @@ class VersionRange(Generic[TEntry]):
 
 _PARSER_REGISTRY: dict[str, list[VersionRange[ParserRegistryEntry]]] = {}
 _RESULT_MODEL_REGISTRY: dict[tuple[AnalysisSoftware, AnalysisType], ModelClass] = {}
+_RESULT_ELEMENT_MODEL_REGISTRY: dict[tuple[str, str], dict[str, ModelClass | TypeAdapter]] = {}
 
 
 def _normalize_version(version: str | Version) -> Version:
@@ -202,6 +203,62 @@ def get_result_model(
     return None  # No result model registered for this software/type
 
 
+def register_result_element_models(
+    software: str | AnalysisSoftware,
+    analysis_type: str | AnalysisType,
+    *,
+    field_models: dict[str, ModelClass | TypeAdapter],
+) -> None:
+    """Register nested element field models for a result type."""
+    key = (str(software), str(analysis_type))
+    if key in _RESULT_ELEMENT_MODEL_REGISTRY:
+        existing = _RESULT_ELEMENT_MODEL_REGISTRY[key]
+        raise ValueError(
+            f"Nested field models already registered for software={software!r}, "
+            f"analysis_type={analysis_type!r}. Existing={list(existing.keys())}"
+        )
+    _RESULT_ELEMENT_MODEL_REGISTRY[key] = field_models.copy()
+
+
+def get_result_element_models(
+    software: str | AnalysisSoftware,
+    analysis_type: str | AnalysisType,
+) -> dict[str, ModelClass | TypeAdapter] | None:
+    """Return nested element field models for a result type."""
+    key = (str(software), str(analysis_type))
+    return _RESULT_ELEMENT_MODEL_REGISTRY.get(key)
+
+
+def _hydrate_raw_value(model_cls: ModelClass | TypeAdapter, raw_value: Any) -> Any:
+    if isinstance(model_cls, TypeAdapter):
+        return model_cls.validate_python(raw_value)
+    if issubclass(model_cls, BaseModel):
+        return model_cls.model_validate(raw_value)
+    raise TypeError(f"Unsupported nested element model type: {type(model_cls).__name__}")
+
+
+def _hydrate_nested_fields(result_obj: BaseModel, field_models: dict[str, ModelClass | TypeAdapter]) -> BaseModel:
+    updates: dict[str, Any] = {}
+
+    for field_name, model_cls in field_models.items():
+        if not hasattr(result_obj, field_name):
+            continue
+
+        raw_value = getattr(result_obj, field_name)
+        if raw_value is None:
+            continue
+
+        if isinstance(raw_value, list):
+            if isinstance(model_cls, TypeAdapter):
+                updates[field_name] = model_cls.validate_python(raw_value)
+            else:
+                updates[field_name] = [_hydrate_raw_value(model_cls, item) for item in raw_value]
+        else:
+            updates[field_name] = _hydrate_raw_value(model_cls, raw_value)
+
+    return result_obj.model_copy(update=updates)
+
+
 def hydrate_result(*, software: str, analysis_type: str, result: dict) -> Any:
     """Hydrate json data into a typed result object or raw data if unknown."""
     if not isinstance(result, dict | list | int | str | float | bool | None):
@@ -216,7 +273,15 @@ def hydrate_result(*, software: str, analysis_type: str, result: dict) -> Any:
     
     if isinstance(model_cls, TypeAdapter):
         return model_cls.validate_python(result)
+
     elif issubclass(model_cls, BaseModel):
-        return model_cls.model_validate(result)
+        result_obj = model_cls.model_validate(result)
+        field_models = get_result_element_models(
+            software=software,
+            analysis_type=analysis_type,
+        )
+        if field_models:
+            return _hydrate_nested_fields(result_obj, field_models)
+        return result_obj
     
     raise TypeError(f"Unsupported model class type for hydration: {type(model_cls).__name__}")

--- a/prp/parse/core/registry.py
+++ b/prp/parse/core/registry.py
@@ -12,11 +12,10 @@ from prp.parse.exceptions import (
     UnsupportedSoftwareError,
     UnsupportedVersionError,
 )
-from prp.parse.models.base import ParserOutput
 from prp.parse.models.enums import AnalysisSoftware, AnalysisType
 
 ParserClass: TypeAlias = type[BaseParser]
-ParserFn: TypeAlias = Callable[..., ParserOutput]
+ParserFn: TypeAlias = Callable[..., "ParserOutput"]
 ParserRegistryEntry: TypeAlias = ParserClass | ParserFn
 ModelClass: TypeAlias = type[BaseModel]
 TEntry = TypeVar("TEntry")
@@ -53,17 +52,38 @@ def register_parser(
     """Decorator to register a parser for a range of versions.
 
     Null values means either undefined or no upper range.
+    Ensures version ranges do not overlap for a given software.
     """
+
     min_version = min_version or "0.0.0"
     max_version = max_version or "99999.0.0"
 
     def wrapper(cls: ParserRegistryEntry):
+        new_min = _normalize_version(min_version)
+        new_max = _normalize_version(max_version)
+
+        # Fetch existing ranges for this software
+        existing_ranges = _PARSER_REGISTRY.get(software, [])
+
+        # Check for overlapping version ranges
+        for span in existing_ranges:
+            if not (new_max < span.min_version or new_min > span.max_version):
+                # Ranges overlap → safety error
+                raise ValueError(
+                    f"Cannot register parser {cls.__name__} for software '{software}' "
+                    f"with version range [{new_min}, {new_max}] because it overlaps "
+                    f"with existing parser {span.entry.__name__} range "
+                    f"[{span.min_version}, {span.max_version}]."
+                )
+
+        # Safe to register
         v_range = VersionRange(
-            min_version=Version(min_version),
-            max_version=Version(max_version),
+            min_version=new_min,
+            max_version=new_max,
             entry=cls,
         )
         _PARSER_REGISTRY.setdefault(software, []).append(v_range)
+
         return cls
 
     return wrapper
@@ -80,7 +100,7 @@ def get_parser(software: str, *, version: str) -> ParserRegistryEntry:
     # Normalize version to PkgVersion
     v = _normalize_version(version)
 
-    for span in sorted(_PARSER_REGISTRY[software]):
+    for span in sorted(_PARSER_REGISTRY[software], key=lambda r: (r.min_version, r.max_version)):
         if span.min_version <= v <= span.max_version:
             return span.entry
 
@@ -102,7 +122,7 @@ def registered_version_ranges(software: str) -> list[VersionRange]:
     return _PARSER_REGISTRY.get(software, [])
 
 
-def resolve_parser(entry, **init_kwargs) -> Callable[..., ParserOutput]:
+def resolve_parser(entry, **init_kwargs) -> Callable[..., "ParserOutput"]:
     """Resolve registry entry to a callable parse function.
 
     If works with both parser classes and parse functions.
@@ -123,7 +143,7 @@ def run_parser(
     want: set[AnalysisType] | None = None,
     parser_init: dict[str, Any] | None = None,
     **parse_kwargs: Any,
-) -> ParserOutput:
+) -> "ParserOutput":
     """Run parser for given software, version and data."""
 
     if not isinstance(software, (AnalysisSoftware, str)):
@@ -140,14 +160,27 @@ def register_result_model(
     software: str | AnalysisSoftware,
     analysis_type: str | AnalysisType,
 ):
-    """Decorator to register a result model."""
-    # Normalise to string keys to keep the registry consistent
+    """Decorator to register a result model.
+    
+    Prevents duplicate registration for the same (software, analysis_type) key.
+    """
+    # Normalize to strings to keep the registry consistent.
     software_key = str(software)
     analysis_type_key = str(analysis_type)
 
     def wrapper(cls: ModelClass) -> ModelClass:
         key = (software_key, analysis_type_key)
-        _RESULT_MODEL_REGISTRY.setdefault(key, cls)
+
+        if key in _RESULT_MODEL_REGISTRY:
+            existing = _RESULT_MODEL_REGISTRY[key].__name__
+            new = cls.__name__
+            raise ValueError(
+                f"Result model already registered for software={software_key!r}, "
+                f"analysis_type={analysis_type_key!r}. "
+                f"Existing model: {existing}, attempted new model: {new}"
+            )
+
+        _RESULT_MODEL_REGISTRY[key] = cls
         return cls
 
     return wrapper

--- a/prp/parse/core/registry.py
+++ b/prp/parse/core/registry.py
@@ -1,9 +1,10 @@
 """Parser registry."""
 
 from dataclasses import dataclass
-from typing import Any, Callable, TypeAlias
+from typing import Any, Callable, Generic, TypeAlias, TypeVar
 
 from packaging.version import InvalidVersion, Version
+from pydantic import BaseModel
 
 from prp.parse.core.base import BaseParser, StreamOrPath
 from prp.parse.exceptions import (
@@ -16,19 +17,34 @@ from prp.parse.models.enums import AnalysisSoftware, AnalysisType
 
 ParserClass: TypeAlias = type[BaseParser]
 ParserFn: TypeAlias = Callable[..., ParserOutput]
-RegistryEntry: TypeAlias = ParserClass | ParserFn
+ParserRegistryEntry: TypeAlias = ParserClass | ParserFn
+ModelClass: TypeAlias = type[BaseModel]
+TEntry = TypeVar("TEntry")
 
 
 @dataclass(order=True, slots=True)
-class VersionRange:
-    """Maps a parser to an inclusive software-version interval."""
+class VersionRange(Generic[TEntry]):
+    """Maps a registry entry to an inclusive software-version interval."""
 
     min_version: Version
     max_version: Version
-    parser: RegistryEntry
+    entry: TEntry
 
 
-_REGISTRY: dict[str, list[VersionRange]] = {}
+_PARSER_REGISTRY: dict[str, list[VersionRange[ParserRegistryEntry]]] = {}
+_RESULT_MODEL_REGISTRY: dict[tuple[AnalysisSoftware, AnalysisType], list[VersionRange[ModelClass]]] = {}
+
+
+def _normalize_version(version: str | Version) -> Version:
+    """Normalize a user supplied version to a packaging.version object."""
+    if isinstance(version, Version):
+        return version
+    if isinstance(version, str):
+        try:
+            return Version(version)
+        except InvalidVersion as exc:
+            raise InvalidDataFormat(f"Invalid version format: {version!r}") from exc
+    raise TypeError(f"Version must be str or Version, got {type(version).__name__}")
 
 
 def register_parser(
@@ -41,19 +57,19 @@ def register_parser(
     min_version = min_version or "0.0.0"
     max_version = max_version or "99999.0.0"
 
-    def wrapper(cls: RegistryEntry):
+    def wrapper(cls: ParserRegistryEntry):
         v_range = VersionRange(
             min_version=Version(min_version),
             max_version=Version(max_version),
-            parser=cls,
+            entry=cls,
         )
-        _REGISTRY.setdefault(software, []).append(v_range)
+        _PARSER_REGISTRY.setdefault(software, []).append(v_range)
         return cls
 
     return wrapper
 
 
-def get_parser(software: str, *, version: str) -> RegistryEntry:
+def get_parser(software: str, *, version: str) -> ParserRegistryEntry:
     """Get parser from registry."""
     if not isinstance(software, str):
         raise TypeError(f"`software` must be str, got {type(software).__name__}")
@@ -62,25 +78,11 @@ def get_parser(software: str, *, version: str) -> RegistryEntry:
         raise UnsupportedSoftwareError(f"No parser registered for software: {software}")
 
     # Normalize version to PkgVersion
-    if isinstance(version, Version):
-        v = version
-    elif isinstance(version, str):
-        try:
-            v = Version(version)
-        except InvalidVersion as exc:
-            # Domain-level input issue → PRP error (not ValueError)
-            raise InvalidDataFormat(
-                f"Invalid version format: {version!r}",
-                context={"software": software, "version": version},
-            ) from exc
-    else:
-        raise TypeError(
-            f"`version` must be str|Version|None, got {type(version).__name__}"
-        )
+    v = _normalize_version(version)
 
-    for span in sorted(_REGISTRY[software]):
+    for span in sorted(_PARSER_REGISTRY[software]):
         if span.min_version <= v <= span.max_version:
-            return span.parser
+            return span.entry
 
     # Return the correct error.
     raise UnsupportedVersionError(
@@ -91,13 +93,13 @@ def get_parser(software: str, *, version: str) -> RegistryEntry:
 def registered_softwares() -> list[str]:
     """Get registered softwares."""
 
-    return list(_REGISTRY.keys())
+    return list(_PARSER_REGISTRY.keys())
 
 
 def registered_version_ranges(software: str) -> list[VersionRange]:
     """Get ranges for registered software."""
 
-    return _REGISTRY.get(software, [])
+    return _PARSER_REGISTRY.get(software, [])
 
 
 def resolve_parser(entry, **init_kwargs) -> Callable[..., ParserOutput]:
@@ -132,3 +134,75 @@ def run_parser(
     ev = parse_fn(data, want=want, **parse_kwargs)
     # add version to results
     return ev.model_copy(update={"software_version": version})
+
+
+def register_result_model(
+    software: str | AnalysisSoftware,
+    analysis_type: str | AnalysisType,
+    *,
+    min_version: str | None = None,
+    max_version: str | None = None,
+):
+    """Decorator to register a result model for a range of software versions.
+
+    Null values mean either undefined or 'no upper limit'.
+    """
+    min_version = min_version or "0.0.0"
+    max_version = max_version or "99999.0.0"
+
+    # Normalise to string keys to keep the registry consistent
+    software_key = str(software)
+    analysis_type_key = str(analysis_type)
+
+    def wrapper(cls: ModelClass) -> ModelClass:
+        v_range = VersionRange(
+            min_version=Version(min_version),
+            max_version=Version(max_version),
+            entry=cls,
+        )
+        key = (software_key, analysis_type_key)
+        _RESULT_MODEL_REGISTRY.setdefault(key, []).append(v_range)
+        return cls
+
+    return wrapper
+
+
+def get_result_model(
+    software: str | AnalysisSoftware,
+    analysis_type: str | AnalysisType,
+    *,
+    version: str,
+) -> ModelClass | None:
+    """Return the registered result model class for software/type/version, or None."""
+    software_key = str(software)
+    analysis_type_key = str(analysis_type)
+    key = (software_key, analysis_type_key)
+
+    ranges = _RESULT_MODEL_REGISTRY.get(key)
+    if not ranges:
+        return None  # No result model registered for this software/type
+
+    v = _normalize_version(version)
+
+    for span in sorted(ranges):
+        if span.min_version <= v <= span.max_version:
+            return span.entry
+
+    # Version not supported → None; let caller decide how to handle
+    return None
+
+
+def hydrate_result(*, software: str, software_version: str, analysis_type: str, result: dict) -> Any:
+    """Hydrate json data into a typed result object or raw data if unknown."""
+    if not isinstance(result, dict):
+        raise ValueError("Expected a dictionary to hydrate the result object.")
+
+    model_cls = get_result_model(
+        software=software,
+        analysis_type=analysis_type,
+        version=software_version,
+    )
+    if model_cls is None:
+        return result
+
+    return model_cls.model_validate(result)

--- a/prp/parse/core/registry.py
+++ b/prp/parse/core/registry.py
@@ -204,8 +204,8 @@ def get_result_model(
 
 def hydrate_result(*, software: str, analysis_type: str, result: dict) -> Any:
     """Hydrate json data into a typed result object or raw data if unknown."""
-    if not isinstance(result, dict):
-        raise ValueError("Expected a dictionary to hydrate the result object.")
+    if not isinstance(result, dict | list | int | str | float | bool | None):
+        raise ValueError("Expected result to be a JSON-serializable dict, list, primitive or None")
 
     model_cls = get_result_model(
         software=software,

--- a/prp/parse/models/base.py
+++ b/prp/parse/models/base.py
@@ -5,6 +5,8 @@ from typing import Any, Collection, Mapping, Self, TypeAlias
 from pydantic import BaseModel, Field, model_validator
 
 from prp.models.base import RWModel
+from prp.models.enums import AnalysisSoftware
+from prp.parse import register_result_model
 from prp.parse.exceptions import AbsentResultError, ParserError
 
 from .enums import (
@@ -218,6 +220,10 @@ class VariantBase(RWModel):
         return self
 
 
+@register_result_model(AnalysisSoftware.AMRFINDER, AnalysisType.AMR)
+@register_result_model(AnalysisSoftware.AMRFINDER, AnalysisType.VIRULENCE)
+@register_result_model(AnalysisSoftware.AMRFINDER, AnalysisType.STRESS)
+@register_result_model(AnalysisSoftware.KLEBORATE, AnalysisType.AMR)
 class ElementTypeResult(BaseModel):
     """Phenotype result data model.
 

--- a/prp/parse/models/base.py
+++ b/prp/parse/models/base.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from prp.models.base import RWModel
 from prp.models.enums import AnalysisSoftware
-from prp.parse import register_result_model
+from prp.parse.core.registry import register_result_model
 from prp.parse.exceptions import AbsentResultError, ParserError
 
 from .enums import (

--- a/prp/parse/models/base.py
+++ b/prp/parse/models/base.py
@@ -221,9 +221,13 @@ class VariantBase(RWModel):
 
 
 @register_result_model(AnalysisSoftware.AMRFINDER, AnalysisType.AMR)
-@register_result_model(AnalysisSoftware.AMRFINDER, AnalysisType.VIRULENCE)
 @register_result_model(AnalysisSoftware.AMRFINDER, AnalysisType.STRESS)
+@register_result_model(AnalysisSoftware.AMRFINDER, AnalysisType.VIRULENCE)
 @register_result_model(AnalysisSoftware.KLEBORATE, AnalysisType.AMR)
+@register_result_model(AnalysisSoftware.MYKROBE, AnalysisType.AMR)
+@register_result_model(AnalysisSoftware.RESFINDER, AnalysisType.AMR)
+@register_result_model(AnalysisSoftware.TBPROFILER, AnalysisType.AMR)
+@register_result_model(AnalysisSoftware.VIRULENCEFINDER, AnalysisType.VIRULENCE)
 class ElementTypeResult(BaseModel):
     """Phenotype result data model.
 

--- a/prp/parse/models/bracken.py
+++ b/prp/parse/models/bracken.py
@@ -1,6 +1,7 @@
 """Bracken specific data models."""
 
-from pydantic import Field
+from typing import TypeAlias
+from pydantic import Field, TypeAdapter
 
 from prp.parse.core.registry import register_result_model
 
@@ -8,7 +9,6 @@ from .base import BaseSpeciesPrediction
 from .enums import TaxLevel, AnalysisSoftware, AnalysisType
 
 
-@register_result_model(AnalysisSoftware.BRACKEN, AnalysisType.SPECIES)
 class BrackenSpeciesPrediction(BaseSpeciesPrediction):
     """Species prediction results."""
 
@@ -16,3 +16,10 @@ class BrackenSpeciesPrediction(BaseSpeciesPrediction):
     kraken_assigned_reads: int = Field(..., alias="krakenAssignedReads")
     added_reads: int = Field(..., alias="addedReads")
     fraction_total_reads: float = Field(..., alias="fractionTotalReads")
+
+BrackenSpeciesPredictions: TypeAlias = list[BrackenSpeciesPrediction]
+
+register_result_model(
+    AnalysisSoftware.BRACKEN,
+    AnalysisType.SPECIES,
+)(TypeAdapter(BrackenSpeciesPredictions))

--- a/prp/parse/models/bracken.py
+++ b/prp/parse/models/bracken.py
@@ -2,10 +2,13 @@
 
 from pydantic import Field
 
+from prp.parse.core.registry import register_result_model
+
 from .base import BaseSpeciesPrediction
-from .enums import TaxLevel
+from .enums import TaxLevel, AnalysisSoftware, AnalysisType
 
 
+@register_result_model(AnalysisSoftware.BRACKEN, AnalysisType.SPECIES)
 class BrackenSpeciesPrediction(BaseSpeciesPrediction):
     """Species prediction results."""
 

--- a/prp/parse/models/kleborate.py
+++ b/prp/parse/models/kleborate.py
@@ -5,11 +5,13 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, field_validator
 
 from prp.models.base import RWModel
+from prp.parse import register_result_model
 
-from .enums import VariantSubType
+from .enums import VariantSubType, AnalysisSoftware, AnalysisType
 from .typing import LineageMixin, TypingResultMlst
 
 
+@register_result_model(AnalysisSoftware.KLEBORATE, AnalysisType.QC)
 class KleborateQcResult(BaseModel):
     """QC metrics reported by Kleborate."""
 
@@ -21,6 +23,7 @@ class KleborateQcResult(BaseModel):
     qc_warnings: None | bool = None
 
 
+@register_result_model(AnalysisSoftware.KLEBORATE, AnalysisType.SPECIES)
 class KleboreateSppResult(RWModel):
     """Species prediction results."""
 
@@ -30,10 +33,16 @@ class KleboreateSppResult(RWModel):
     )
 
 
+@register_result_model(AnalysisSoftware.KLEBORATE, AnalysisType.ABST)
+@register_result_model(AnalysisSoftware.KLEBORATE, AnalysisType.CBST)
+@register_result_model(AnalysisSoftware.KLEBORATE, AnalysisType.RMST)
+@register_result_model(AnalysisSoftware.KLEBORATE, AnalysisType.SMST)
+@register_result_model(AnalysisSoftware.KLEBORATE, AnalysisType.YBST)
 class KleborateMlstLikeResults(TypingResultMlst, LineageMixin):
     """Kleborate MLST-like analysis"""
 
 
+@register_result_model(AnalysisSoftware.KLEBORATE, AnalysisType.VIRULENCE)
 class KleborateEtScore(RWModel):
     """Records and validate score."""
 
@@ -41,6 +50,8 @@ class KleborateEtScore(RWModel):
     spurious_hits: Any
 
 
+@register_result_model(AnalysisSoftware.KLEBORATE, AnalysisType.K_TYPE)
+@register_result_model(AnalysisSoftware.KLEBORATE, AnalysisType.O_TYPE)
 class KleborateKaptiveLocus(RWModel):
     """Kleboraete curation of Kaptive typing."""
 

--- a/prp/parse/models/kleborate.py
+++ b/prp/parse/models/kleborate.py
@@ -5,7 +5,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, field_validator
 
 from prp.models.base import RWModel
-from prp.parse import register_result_model
+from prp.parse.core.registry import register_result_model
 
 from .enums import VariantSubType, AnalysisSoftware, AnalysisType
 from .typing import LineageMixin, TypingResultMlst

--- a/prp/parse/models/mykrobe.py
+++ b/prp/parse/models/mykrobe.py
@@ -4,9 +4,13 @@ from dataclasses import dataclass
 
 from pydantic import Field
 
+from prp.parse.core.registry import register_result_model
+
 from .base import BaseSpeciesPrediction
+from .enums import AnalysisType, AnalysisSoftware
 
 
+@register_result_model(AnalysisSoftware.MYKROBE, AnalysisType.SPECIES)
 class MykrobeSpeciesPrediction(BaseSpeciesPrediction):
     """Mykrobe species prediction results."""
 

--- a/prp/parse/models/mykrobe.py
+++ b/prp/parse/models/mykrobe.py
@@ -1,8 +1,9 @@
 """Mykrobe specific data models."""
 
+from typing import TypeAlias
 from dataclasses import dataclass
 
-from pydantic import Field
+from pydantic import Field, TypeAdapter
 
 from prp.parse.core.registry import register_result_model
 
@@ -10,7 +11,6 @@ from .base import BaseSpeciesPrediction
 from .enums import AnalysisType, AnalysisSoftware
 
 
-@register_result_model(AnalysisSoftware.MYKROBE, AnalysisType.SPECIES)
 class MykrobeSpeciesPrediction(BaseSpeciesPrediction):
     """Mykrobe species prediction results."""
 
@@ -22,6 +22,12 @@ class MykrobeSpeciesPrediction(BaseSpeciesPrediction):
     )
     species_coverage: float = Field(..., description="Species kmer converage.")
 
+
+MykrobeSpeciesPredictions: TypeAlias = list[MykrobeSpeciesPrediction]
+register_result_model(
+    AnalysisSoftware.MYKROBE,
+    AnalysisType.SPECIES,
+)(TypeAdapter(MykrobeSpeciesPredictions))
 
 @dataclass(frozen=True)
 class SRProfile:

--- a/prp/parse/models/phenotype.py
+++ b/prp/parse/models/phenotype.py
@@ -2,6 +2,9 @@
 
 from pydantic import Field
 
+from prp.models.enums import AnalysisSoftware, AnalysisType
+from prp.parse.core.registry import register_result_element_models
+
 from .base import DatabaseReferenceMixin, GeneBase, PhenotypeModelMixin, VariantBase
 from .enums import SequenceStrand
 
@@ -51,3 +54,27 @@ class TbProfilerVariant(VariantBase):
     hgvs_aa_change: str | None = Field(
         default=None, description="Protein change in HGVS format"
     )
+
+# ---------------------------------------------------------------------------
+# Register phenotype models
+
+register_result_element_models(
+    AnalysisSoftware.AMRFINDER,
+    AnalysisType.AMR,
+    field_models={
+        "genes": AmrFinderResistanceGene,
+        "variants": AmrFinderVariant,
+    },
+)
+
+register_result_element_models(
+    AnalysisSoftware.AMRFINDER,
+    AnalysisType.VIRULENCE,
+    field_models={"genes": AmrFinderVirulenceGene},
+)
+
+register_result_element_models(
+    AnalysisSoftware.TBPROFILER,
+    AnalysisType.AMR,
+    field_models={"variants": TbProfilerVariant},
+)

--- a/prp/parse/models/qc.py
+++ b/prp/parse/models/qc.py
@@ -2,9 +2,12 @@
 
 from pydantic import BaseModel, Field
 
-from .enums import GambitQcFlag
+from prp.parse.core.registry import register_result_model
+
+from .enums import GambitQcFlag, AnalysisSoftware, AnalysisType
 
 
+@register_result_model(AnalysisSoftware.QUAST, AnalysisType.QC)
 class QuastQcResult(BaseModel):
     """Assembly QC metrics."""
 
@@ -19,6 +22,7 @@ class QuastQcResult(BaseModel):
     duplication_ratio: float | None = None
 
 
+@register_result_model(AnalysisSoftware.POSTALIGNQC, AnalysisType.QC)
 class PostAlignQcResult(BaseModel):
     """Alignment QC metrics."""
 
@@ -41,6 +45,7 @@ class GenomeCompleteness(BaseModel):
     n_missing: int = Field(..., description="Number of missing cgMLST alleles")
 
 
+@register_result_model(AnalysisSoftware.GAMBIT, AnalysisType.QC)
 class GambitcoreQcResult(BaseModel):
     """Gambitcore genome completeness QC metrics."""
 
@@ -79,6 +84,7 @@ class NanoPlotQcCutoff(BaseModel):
     q30: float
 
 
+@register_result_model(AnalysisSoftware.NANOPLOT, AnalysisType.QC)
 class NanoPlotQcResult(BaseModel):
     """Nanopore sequencing QC metrics from NanoPlot."""
 
@@ -102,6 +108,7 @@ class ContigCoverage(BaseModel):
     mean_map_quality: float
 
 
+@register_result_model(AnalysisSoftware.SAMTOOLS, AnalysisType.QC)
 class SamtoolsCoverageQcResult(BaseModel):
     """SAMtools coverage QC result model."""
 

--- a/prp/parse/models/typing.py
+++ b/prp/parse/models/typing.py
@@ -5,7 +5,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from prp.models.base import RWModel
-from prp.parse import register_result_model
+from prp.parse.core.registry import register_result_model
 from .enums import AnalysisSoftware, AnalysisType
 
 

--- a/prp/parse/models/typing.py
+++ b/prp/parse/models/typing.py
@@ -5,6 +5,8 @@ from typing import Any
 from pydantic import BaseModel
 
 from prp.models.base import RWModel
+from prp.parse import register_result_model
+from .enums import AnalysisSoftware, AnalysisType
 
 
 class ResultMlstBase(BaseModel):
@@ -20,6 +22,7 @@ class TypingResultMlst(ResultMlstBase):
     sequence_type: int | str | None = None
 
 
+@register_result_model(AnalysisSoftware.CHEWBBACA, AnalysisType.CGMLST)
 class TypingResultCgMlst(ResultMlstBase):
     """MLST results"""
 
@@ -27,6 +30,7 @@ class TypingResultCgMlst(ResultMlstBase):
     n_missing: int = 0
 
 
+@register_result_model(AnalysisSoftware.EMMTYPER, AnalysisType.EMM)
 class TypingResultEmm(BaseModel):
     """Container for emmtype gene information"""
 

--- a/prp/parse/models/typing.py
+++ b/prp/parse/models/typing.py
@@ -15,6 +15,7 @@ class ResultMlstBase(BaseModel):
     alleles: dict[str, int | str | list | None]
 
 
+@register_result_model(AnalysisSoftware.MLST, AnalysisType.MLST)
 class TypingResultMlst(ResultMlstBase):
     """MLST results"""
 

--- a/prp/parse/models/typing.py
+++ b/prp/parse/models/typing.py
@@ -1,8 +1,8 @@
 """Chewbacca specific models."""
 
-from typing import Any
+from typing import Any, TypeAlias
 
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
 
 from prp.models.base import RWModel
 from prp.parse.core.registry import register_result_model
@@ -57,6 +57,11 @@ class LineageInformation(RWModel):
     support: list[dict[str, Any]] | None = None
 
 
+LineageResults: TypeAlias = list[LineageInformation]
+register_result_model(AnalysisSoftware.TBPROFILER, AnalysisType.LINEAGE)(TypeAdapter(LineageResults))
+
+
+@register_result_model(AnalysisSoftware.MYKROBE, AnalysisType.LINEAGE)
 class ResultLineageBase(RWModel):
     """Lineage results"""
 
@@ -65,6 +70,7 @@ class ResultLineageBase(RWModel):
     sublineage: str
 
 
+@register_result_model(AnalysisSoftware.SCCMECTYPER, AnalysisType.SCCMEC)
 class TypingResultSccmec(RWModel):
     """Sccmec results"""
 
@@ -85,6 +91,7 @@ class TypingResultSccmec(RWModel):
     comment: str | None = None
 
 
+@register_result_model(AnalysisSoftware.SPATYPER, AnalysisType.SPATYPE)
 class TypingResultSpatyper(RWModel):
     """Spatyper results"""
 
@@ -93,6 +100,7 @@ class TypingResultSpatyper(RWModel):
     type: str | None
 
 
+@register_result_model(AnalysisSoftware.SHIGAPASS, AnalysisType.SHIGATYPE)
 class TypingResultShiga(RWModel):
     """Container for shigatype gene information"""
 

--- a/prp/parse/parsers/amrfinder.py
+++ b/prp/parse/parsers/amrfinder.py
@@ -7,7 +7,8 @@ from typing import Any, TypeAlias
 
 from prp.io.delimited import normalize_nulls, read_delimited
 from prp.io.types import StreamOrPath
-from prp.parse.core.base import BaseParser, ParseImplOut
+from prp.parse.core.base import BaseParser
+from prp.parse.models.base import ParseImplOut
 from prp.parse.core.envelope import run_as_envelope
 from prp.parse.core.registry import register_parser
 from prp.parse.models.base import ElementTypeResult, PhenotypeInfo

--- a/prp/parse/parsers/bracken.py
+++ b/prp/parse/parsers/bracken.py
@@ -6,7 +6,7 @@ from prp.io.delimited import read_delimited
 from prp.parse.core.base import SingleAnalysisParser, StreamOrPath
 from prp.parse.core.registry import register_parser
 from prp.parse.exceptions import ParserError
-from prp.parse.models.bracken import BrackenSpeciesPrediction
+from prp.parse.models.bracken import BrackenSpeciesPrediction, BrackenSpeciesPredictions
 from prp.parse.models.enums import AnalysisSoftware, AnalysisType, TaxLevel
 
 from .utils import safe_float, safe_int
@@ -62,7 +62,7 @@ class BrackenParser(SingleAnalysisParser):
         cutoff: float | None = None,
         strict_columns: bool = False,
         **_,
-    ) -> list[BrackenSpeciesPrediction]:
+    ) -> BrackenSpeciesPredictions:
         """Parse Bracken results."""
         rows = read_delimited(source)
         try:
@@ -76,7 +76,7 @@ class BrackenParser(SingleAnalysisParser):
             first_row, required=REQUIRED_COLUMNS, strict=strict_columns
         )
 
-        results: list[BrackenSpeciesPrediction] = []
+        results: BrackenSpeciesPredictions = []
         # append first row
         if spp_obj := self._to_spp_results(first_row, cutoff=cutoff):
             results.append(spp_obj)

--- a/prp/parse/parsers/kleborate.py
+++ b/prp/parse/parsers/kleborate.py
@@ -9,7 +9,9 @@ from itertools import chain
 from typing import Any, Callable, Literal, Mapping
 
 from prp.io.delimited import DelimiterRow, is_nullish, normalize_row, read_delimited
-from prp.parse.core.base import BaseParser, ParseImplOut, StreamOrPath
+from prp.io.types import StreamOrPath
+from prp.parse.core.base import BaseParser
+from prp.parse.models.base import ParseImplOut
 from prp.parse.core.envelope import (
     envelope_absent,
     envelope_error,

--- a/prp/parse/parsers/mlst.py
+++ b/prp/parse/parsers/mlst.py
@@ -68,7 +68,7 @@ class MlstParser(SingleAnalysisParser):
     schema_version = 1
     produces = {AnalysisType.MLST}
 
-    def _parse_one(self, source, *, strict: bool = False, **kwargs):
+    def _parse_one(self, source, *, strict: bool = False, **kwargs) -> TypingResultMlst:
         """Parser implementation."""
 
         # read analysis result

--- a/prp/parse/parsers/mykrobe.py
+++ b/prp/parse/parsers/mykrobe.py
@@ -32,7 +32,7 @@ from prp.parse.models.enums import (
     VariantSubType,
     VariantType,
 )
-from prp.parse.models.mykrobe import MykrobeSpeciesPrediction, SRProfile
+from prp.parse.models.mykrobe import MykrobeSpeciesPredictions, MykrobeSpeciesPrediction, SRProfile
 from prp.parse.models.typing import ResultLineageBase
 
 from .utils import get_nt_change, safe_float, safe_int
@@ -212,7 +212,7 @@ def _parse_amr_variants(rows: TableRows, *, log_warning) -> list[VariantBase]:
     return out
 
 
-def _parse_species(rows: TableRows) -> list[MykrobeSpeciesPrediction]:
+def _parse_species(rows: TableRows) -> MykrobeSpeciesPredictions:
     """Parse Mykrobe species predictions."""
     if not rows:
         return []
@@ -224,7 +224,7 @@ def _parse_species(rows: TableRows) -> list[MykrobeSpeciesPrediction]:
     phylo_covg = _split_csv_list("phylo_group_per_covg", row=r0)
     species_covg = _split_csv_list("species_per_covg", row=r0)
 
-    out: list[MykrobeSpeciesPrediction] = []
+    out: MykrobeSpeciesPredictions = []
     for idx, spp in enumerate(species):
         if not spp.strip():
             continue

--- a/prp/parse/parsers/mykrobe.py
+++ b/prp/parse/parsers/mykrobe.py
@@ -12,7 +12,9 @@ from prp.io.delimited import (
     normalize_row,
     read_delimited,
 )
-from prp.parse.core.base import BaseParser, ParseImplOut, StreamOrPath
+from prp.io.types import StreamOrPath
+from prp.parse.core.base import BaseParser
+from prp.parse.models.base import ParseImplOut
 from prp.parse.core.envelope import run_as_envelope
 from prp.parse.core.registry import register_parser
 from prp.parse.models.base import (

--- a/prp/parse/parsers/resfinder.py
+++ b/prp/parse/parsers/resfinder.py
@@ -5,7 +5,9 @@ from itertools import chain
 from typing import Any
 
 from prp.io.json import read_json, require_mapping
-from prp.parse.core.base import BaseParser, ParseImplOut, StreamOrPath
+from prp.io.types import StreamOrPath
+from prp.parse.core.base import BaseParser 
+from prp.parse.models.base import ParseImplOut
 from prp.parse.core.envelope import run_as_envelope
 from prp.parse.core.registry import register_parser
 from prp.parse.exceptions import InvalidDataFormat

--- a/prp/parse/parsers/serotypefinder.py
+++ b/prp/parse/parsers/serotypefinder.py
@@ -4,7 +4,9 @@ from typing import Any
 
 from prp.io.delimited import is_nullish
 from prp.io.json import read_json
-from prp.parse.core.base import BaseParser, ParseImplOut, StreamOrPath
+from prp.io.types import StreamOrPath
+from prp.parse.core.base import BaseParser
+from prp.parse.models.base import ParseImplOut
 from prp.parse.core.envelope import envelope_absent, run_as_envelope
 from prp.parse.core.registry import register_parser
 from prp.parse.exceptions import InvalidDataFormat, ParserError

--- a/prp/parse/parsers/tbprofiler.py
+++ b/prp/parse/parsers/tbprofiler.py
@@ -3,7 +3,9 @@
 from typing import Any, Sequence
 
 from prp.io.json import read_json
-from prp.parse.core.base import BaseParser, ParseImplOut, StreamOrPath
+from prp.io.types import StreamOrPath
+from prp.parse.core.base import BaseParser
+from prp.parse.models.base import ParseImplOut
 from prp.parse.core.envelope import run_as_envelope
 from prp.parse.core.registry import register_parser
 from prp.parse.exceptions import AbsentResultError

--- a/prp/parse/parsers/tbprofiler.py
+++ b/prp/parse/parsers/tbprofiler.py
@@ -20,7 +20,7 @@ from prp.parse.models.enums import (
     VariantType,
 )
 from prp.parse.models.phenotype import TbProfilerVariant
-from prp.parse.models.typing import LineageInformation
+from prp.parse.models.typing import LineageInformation, LineageResults
 
 from .utils import get_db_version
 
@@ -157,7 +157,7 @@ def parse_drug_resistance_info(drugs: list[dict[str, str]]) -> list[PhenotypeInf
     return phenotypes
 
 
-def _to_lineage_result(pred: dict[str, Any]) -> list[LineageInformation]:
+def _to_lineage_result(pred: dict[str, Any]) -> LineageResults:
     """Transpose prediction result into a lineage object."""
 
     return [

--- a/prp/parse/parsers/virulencefinder.py
+++ b/prp/parse/parsers/virulencefinder.py
@@ -4,7 +4,9 @@ import logging
 from typing import Any
 
 from prp.io.json import read_json, require_mapping
-from prp.parse.core.base import BaseParser, ParseImplOut, StreamOrPath
+from prp.io.types import StreamOrPath
+from prp.parse.core.base import BaseParser
+from prp.parse.models.base import ParseImplOut
 from prp.parse.core.envelope import run_as_envelope
 from prp.parse.core.registry import register_parser
 from prp.parse.exceptions import InvalidDataFormat

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from prp.models.metadata import PipelineInfo, PipelineProvenance, PipelineRun, SequencingInfo
 from prp.models.sample import PipelineResult
+from prp.parse.core.registry import _PARSER_REGISTRY, _RESULT_MODEL_REGISTRY
 
 from .fixtures import *
 
@@ -12,6 +13,16 @@ from .fixtures import *
 def data_path() -> Path:
     """Get path of this file"""
     return Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture(autouse=True)
+def clear_registry_before_each_test():
+    """Ensure a clean registry for each test."""
+    _PARSER_REGISTRY.clear()
+    _RESULT_MODEL_REGISTRY.clear()
+    yield
+    _PARSER_REGISTRY.clear()
+    _RESULT_MODEL_REGISTRY.clear()
 
 
 @pytest.fixture()

--- a/tests/parse/test_bracken.py
+++ b/tests/parse/test_bracken.py
@@ -4,7 +4,7 @@ import pytest
 
 from prp.parse.models.base import ParserOutput, ResultEnvelope
 from prp.parse.models.bracken import BrackenSpeciesPrediction
-from prp.parse.models.enums import TaxLevel
+from prp.parse.models.enums import TaxLevel, AnalysisType
 from prp.parse.parsers.bracken import BrackenParser, to_taxlevel
 
 EXPECTED_PARSER_RESULT = [
@@ -26,7 +26,7 @@ def test_bracken_cutoff(fixture_name, expected, request):
     # assert correct ouptut data model
     assert isinstance(result, ParserOutput)
 
-    spp = result.results["species"]
+    spp = result.results[AnalysisType.SPECIES]
     assert isinstance(spp, ResultEnvelope)
 
     assert spp.status == "parsed"

--- a/tests/parse/test_core_registry.py
+++ b/tests/parse/test_core_registry.py
@@ -1,0 +1,165 @@
+"""Tests for parser and result-model registry behavior."""
+
+import pytest
+from packaging.version import Version
+
+from prp.parse.exceptions import InvalidDataFormat, UnsupportedVersionError
+from prp.parse.core.registry import (
+    VersionRange,
+    _normalize_version,
+    register_parser,
+    register_result_model,
+    _PARSER_REGISTRY,
+    _RESULT_MODEL_REGISTRY,
+    get_parser,
+    get_result_model,
+)
+
+
+# ---------------------------------------------------------------------------
+# Dummy Classes
+# ---------------------------------------------------------------------------
+
+class DummyParser:
+    pass
+
+class DummyParser2:
+    pass
+
+class DummyModel:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Version Normalization
+# ---------------------------------------------------------------------------
+
+def test_normalize_version_happy_path():
+    """Version normalization accepts strings and Version objects."""
+    cases = ["1.0.0", "1.0", "1", Version("2.3.4")]
+
+    for value in cases:
+        result = _normalize_version(value)
+        assert isinstance(result, Version)
+
+
+def test_normalize_version_invalid_inputs():
+    """Invalid or inappropriate version formats raise clear exceptions."""
+    with pytest.raises(InvalidDataFormat):
+        _normalize_version("invalid")
+
+    with pytest.raises(TypeError):
+        _normalize_version(lambda: None)
+
+
+# ---------------------------------------------------------------------------
+# Parser Registration — Version Range Safety
+# ---------------------------------------------------------------------------
+
+def assert_registers(software, min_v, max_v, cls):
+    """Helper to register and retrieve stored version ranges."""
+    register_parser(software, min_v, max_v)(cls)
+    return _PARSER_REGISTRY[software]
+
+
+def test_register_single_range():
+    """Registering one parser stores one version range."""
+    ranges = assert_registers("tool", "1.0.0", "2.0.0", DummyParser)
+
+    assert len(ranges) == 1
+    vr = ranges[0]
+    assert isinstance(vr, VersionRange)
+    assert vr.entry is DummyParser
+    assert vr.min_version == Version("1.0.0")
+    assert vr.max_version == Version("2.0.0")
+
+
+def test_non_overlapping_ranges_allowed():
+    """Two non-overlapping ranges should register without error."""
+    assert_registers("tool", "1.0.0", "2.0.0", DummyParser)
+    assert_registers("tool", "2.1.0", "3.0.0", DummyParser2)
+
+    ranges = sorted(_PARSER_REGISTRY["tool"], key=lambda r: r.min_version)
+    assert [r.entry for r in ranges] == [DummyParser, DummyParser2]
+
+
+@pytest.mark.parametrize(
+    "existing, new",
+    [
+        (("1.0.0", "3.0.0"), ("2.0.0", "4.0.0")),  # partial overlap
+        (("1.0.0", "5.0.0"), ("2.0.0", "3.0.0")),  # containment
+        (("1.0.0", "2.0.0"), ("1.0.0", "2.0.0")),  # exact match
+        (("1.0.0", "2.0.0"), ("2.0.0", "3.0.0")),  # touching edge (inclusive overlap)
+    ]
+)
+def test_overlapping_ranges_rejected(existing, new):
+    """All forms of overlap should raise ValueError."""
+    (e_min, e_max), (n_min, n_max) = existing, new
+
+    assert_registers("tool", e_min, e_max, DummyParser)
+
+    with pytest.raises(ValueError):
+        assert_registers("tool", n_min, n_max, DummyParser2)
+
+
+def test_mixed_version_types_still_overlap():
+    """Mixing Version objects and strings still applies overlap rules."""
+    assert_registers("tool", Version("1.0.0"), Version("2.0.0"), DummyParser)
+
+    with pytest.raises(ValueError):
+        assert_registers("tool", "1.5.0", "2.5.0", DummyParser2)
+
+
+# ---------------------------------------------------------------------------
+# Parser Retrieval
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("version", ["1.0.0", "1.2.0", "1.5.0"])
+def test_get_supported_parser(version):
+    """get_parser returns the expected parser for supported versions."""
+    assert_registers("tool", "1.0.0", "1.5.0", DummyParser)
+
+    parser = get_parser("tool", version=version)
+    assert parser == DummyParser
+
+
+@pytest.mark.parametrize("version", ["0.9.0", "1.5.1"])
+def test_get_unsupported_parser(version):
+    """Unsupported versions should raise UnsupportedVersionError."""
+    assert_registers("tool", "1.0.0", "1.5.0", DummyParser)
+
+    with pytest.raises(UnsupportedVersionError):
+        get_parser("tool", version=version)
+
+
+# ---------------------------------------------------------------------------
+# Result Model Registration
+# ---------------------------------------------------------------------------
+
+def test_register_result_model():
+    """Result models register correctly under (software, analysis)."""
+    register_result_model("soft", "analysis")(DummyModel)
+    assert ("soft", "analysis") in _RESULT_MODEL_REGISTRY
+
+
+def test_reregister_result_model_throws_error():
+    """Re-registering a model for the same (software, analysis) should raise."""
+    register_result_model("soft", "analysis")(DummyModel)
+
+    with pytest.raises(ValueError):
+        register_result_model("soft", "analysis")(DummyModel)
+
+
+@pytest.mark.parametrize(
+    "key, exists",
+    [
+        (("soft", "analysis"), True),
+        (("soft", "missing"), False),
+    ]
+)
+def test_get_result_model(key, exists):
+    """get_result_model returns model only when registered."""
+    register_result_model("soft", "analysis")(DummyModel)
+    result = get_result_model(*key)
+
+    assert (result == DummyModel) == exists

--- a/tests/parse/test_core_registry.py
+++ b/tests/parse/test_core_registry.py
@@ -2,6 +2,8 @@
 
 import pytest
 from packaging.version import Version
+from typing import Any
+from pydantic import BaseModel
 
 from prp.parse.exceptions import InvalidDataFormat, UnsupportedVersionError
 from prp.parse.core.registry import (
@@ -9,10 +11,12 @@ from prp.parse.core.registry import (
     _normalize_version,
     register_parser,
     register_result_model,
+    register_result_element_models,
     _PARSER_REGISTRY,
     _RESULT_MODEL_REGISTRY,
     get_parser,
     get_result_model,
+    hydrate_result,
 )
 
 
@@ -163,3 +167,32 @@ def test_get_result_model(key, exists):
     result = get_result_model(*key)
 
     assert (result == DummyModel) == exists
+
+
+class DummyElementTypeResult(BaseModel):
+    genes: list[Any] = []
+    variants: list[Any] = []
+
+
+class DummyGene(BaseModel):
+    name: str
+
+
+class DummyVariant(BaseModel):
+    pos: int
+
+
+def test_register_result_element_models_and_hydrate_nested_fields():
+    register_result_model("soft", "analysis")(DummyElementTypeResult)
+    register_result_element_models(
+        "soft",
+        "analysis",
+        field_models={"genes": DummyGene, "variants": DummyVariant},
+    )
+
+    raw = {"genes": [{"name": "g1"}], "variants": [{"pos": 42}]}
+    hydrated = hydrate_result(software="soft", analysis_type="analysis", result=raw)
+
+    assert isinstance(hydrated, DummyElementTypeResult)
+    assert isinstance(hydrated.genes[0], DummyGene)
+    assert isinstance(hydrated.variants[0], DummyVariant)

--- a/tests/parse/test_kleborate.py
+++ b/tests/parse/test_kleborate.py
@@ -125,7 +125,7 @@ TEST_ASSAYS_WO_HAMRONIZATION = [
             "qc": "parsed",
             "rmst": "absent",
             "smst": "absent",
-            "species": "parsed",
+            "species_prediction": "parsed",
             "virulence": "absent",
             "ybst": "absent",
         },

--- a/tests/parse/test_mykrobe.py
+++ b/tests/parse/test_mykrobe.py
@@ -1,5 +1,6 @@
 """Test Mykrobe parser."""
 
+from prp.models.enums import AnalysisType
 from prp.parse.models.base import ElementTypeResult, ParserOutput, ResultEnvelope
 from prp.parse.models.typing import ResultLineageBase
 from prp.parse.parsers.mykrobe import MykrobeParser
@@ -18,7 +19,7 @@ def test_mykrobe_parser_results(mtuberculosis_mykrobe_path):
     result_types = list(result.results.keys())
     assert all(method in result_types for method in parser.produces)
 
-    spp = result.results["species"]
+    spp = result.results[AnalysisType.SPECIES]
     assert isinstance(spp, ResultEnvelope)
 
     # verify that species prediction was included


### PR DESCRIPTION
The PR introduces functions to hydrate (cast) JSON results to a result data model. This can be used to cast and validate results stored in a database.

The function works by looking up the relevant data model from *software* and *analysis type*. These are stored in a local registry dictionary. Models are registered using the *register_result_model* decorator, similar to how parser functions are registered. 

I also added CI/CD tests.